### PR TITLE
add an extra filecache in setup.py

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -26,6 +26,13 @@ The `FileCache` is similar to the caching mechanism provided by
 httplib2_. It requires `lockfile`_ be installed as it prevents
 multiple threads from writing to the same file at the same time.
 
+.. note::
+
+  Note that you can install this dependency automatically with pip
+  by requesting the *filecache* extra: ::
+
+    pip install cachecontrol[filecache]
+
 Here is an example using the `FileCache`: ::
 
   import requests

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup_params = dict(
     install_requires=[
         'requests',
     ],
+    extras_require = {
+        'filecache': ['lockfile'],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
This allows to use pip with a requirement like 'cachecontrol[filecache]' to automatically install the lockfile dependency. (See https://pip.readthedocs.org/en/1.1/requirements.html#the-requirements-file-format)

Currently I use cache control in one project, and I have something like this in my setup.py:

install_requires = [
    'cachecontrol',
    'lockfile', # this is required for the cache control with file cache use
  ]

This patch will allow me to write instead:
install_requires = [
    'cachecontrol[filecache]',
  ]

What do you think ?