### PR TITLE
Use JSON to serialize the cache instead of pickle

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -1,8 +1,27 @@
+import base64
 import io
+import json
+import zlib
 
 from requests.structures import CaseInsensitiveDict
 
 from .compat import HTTPResponse, pickle
+
+
+def _b64_encode_bytes(b):
+    return base64.b64encode(b).decode("ascii")
+
+
+def _b64_encode_str(s):
+    return _b64_encode_bytes(s.encode("utf8"))
+
+
+def _b64_decode_bytes(b):
+    return base64.b64decode(b.encode("ascii"))
+
+
+def _b64_decode_str(s):
+    return _b64_decode_bytes(s).decode("utf8")
 
 
 class Serializer(object):
@@ -16,11 +35,14 @@ class Serializer(object):
 
         data = {
             "response": {
-                "body": body,
-                "headers": response.headers,
+                "body": _b64_encode_bytes(body),
+                "headers": dict(
+                    (_b64_encode_str(k), _b64_encode_str(v))
+                    for k, v in response.headers.items()
+                ),
                 "status": response.status,
                 "version": response.version,
-                "reason": response.reason,
+                "reason": _b64_encode_str(response.reason),
                 "strict": response.strict,
                 "decode_content": response.decode_content,
             },
@@ -34,7 +56,20 @@ class Serializer(object):
                 header = header.strip()
                 data["vary"][header] = request.headers.get(header, None)
 
-        return b"cc=1," + pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
+        # Encode our Vary headers to ensure they can be serialized as JSON
+        data["vary"] = dict(
+            (_b64_encode_str(k), _b64_encode_str(v))
+            for k, v in data["vary"].items()
+        )
+
+        return b",".join([
+            b"cc=2",
+            zlib.compress(
+                json.dumps(
+                    data, separators=(",", ":"), sort_keys=True,
+                ).encode("utf8"),
+            ),
+        ])
 
     def loads(self, request, data):
         # Short circuit if we've been given an empty set of data
@@ -76,6 +111,46 @@ class Serializer(object):
             cached = pickle.loads(data)
         except ValueError:
             return
+
+        # Special case the '*' Vary value as it means we cannot actually
+        # determine if the cached response is suitable for this request.
+        if "*" in cached.get("vary", {}):
+            return
+
+        # Ensure that the Vary headers for the cached response match our
+        # request
+        for header, value in cached.get("vary", {}).items():
+            if request.headers.get(header, None) != value:
+                return
+
+        body = io.BytesIO(cached["response"].pop("body"))
+        return HTTPResponse(
+            body=body,
+            preload_content=False,
+            **cached["response"]
+        )
+
+    def _loads_v2(self, request, data):
+        try:
+            cached = json.loads(zlib.decompress(data).decode("utf8"))
+        except ValueError:
+            return
+
+        # We need to decode the items that we've base64 encoded
+        cached["response"]["body"] = _b64_decode_bytes(
+            cached["response"]["body"]
+        )
+        cached["response"]["headers"] = dict(
+            (_b64_decode_str(k), _b64_decode_str(v))
+            for k, v in cached["response"]["headers"].items()
+        )
+        cached["response"]["reason"] = _b64_decode_str(
+            cached["response"]["reason"],
+        )
+        cached["vary"] = dict(
+            (_b64_decode_str(k), _b64_decode_str(v))
+            for k, v in cached["vary"].items()
+        )
 
         # Special case the '*' Vary value as it means we cannot actually
         # determine if the cached response is suitable for this request.


### PR DESCRIPTION
This solves a few issues with the current cache:

* Due to the use of ``pickle.HIGHEST_PROTOCOL`` a cache that is created on Python 3.4 is not able to be loaded on Python 2.7 which can cause things to miss the cache just because of the pickle protocol.
* Pickle itself is an insecure serialization format, by using JSON we'll instead not load files that can execute arbitrary code.
  * In order to support arbitrary binary data this will use base64 encoding to turn them into strings. It has to do some encoding dances to make sure that the ``bytes``/``str `` types are correct. I'm not 100% sure that using ``utf8`` to encode strings that urllib3 has for request headers and the such will work though in all situations (maybe @sigmavirus24 knows?)
* Reduces file size of the cache itself by compressing the cached object.