### PR TITLE
implement heuristic from rfc7234

### DIFF
--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -188,3 +188,58 @@ class TestCacheControlRequest(object):
         self.c.cache = cache
         r = self.req({})
         assert not r
+
+    def test_cache_request_fresh_last_modified(self):
+        later = time.time() - 86400  # GMT - 1 day
+        last_modified = time.strftime(TIME_FMT, time.gmtime(later))
+        now = time.strftime(TIME_FMT, time.gmtime())
+        resp = Mock(headers={'last-modified': last_modified,
+                             'date': now})
+        cache = DictCache({self.url: resp})
+        self.c.cache = cache
+        r = self.req({})
+        assert r == resp
+
+    def test_cache_request_fresh_last_modified_2H(self):
+        later = time.time() - 86400  # GMT - 1 day
+        last_modified = time.strftime(TIME_FMT, time.gmtime(later))
+        now = time.strftime(TIME_FMT, time.gmtime(time.time() - 2*3600))
+        resp = Mock(headers={'last-modified': last_modified,
+                             'date': now})
+        cache = DictCache({self.url: resp})
+        self.c.cache = cache
+        r = self.req({})
+        assert r == resp
+
+    def test_cache_request_stale_last_modified_3H(self):
+        later = time.time() - 86400  # GMT - 1 day
+        last_modified = time.strftime(TIME_FMT, time.gmtime(later))
+        now = time.strftime(TIME_FMT, time.gmtime(time.time() - 3*3600))
+        resp = Mock(headers={'last-modified': last_modified,
+                             'date': now})
+        cache = DictCache({self.url: resp})
+        self.c.cache = cache
+        r = self.req({})
+        assert not r
+
+    def test_cache_request_fresh_last_modified_23H(self):
+        later = time.time() - 20*86400  # GMT - 1 day
+        last_modified = time.strftime(TIME_FMT, time.gmtime(later))
+        now = time.strftime(TIME_FMT, time.gmtime(time.time() - 23*3600))
+        resp = Mock(headers={'last-modified': last_modified,
+                             'date': now})
+        cache = DictCache({self.url: resp})
+        self.c.cache = cache
+        r = self.req({})
+        assert r == resp
+
+    def test_cache_request_stale_last_modified_24H(self):
+        later = time.time() - 20*86400  # GMT - 1 day
+        last_modified = time.strftime(TIME_FMT, time.gmtime(later))
+        now = time.strftime(TIME_FMT, time.gmtime(time.time() - 24*3600))
+        resp = Mock(headers={'last-modified': last_modified,
+                             'date': now})
+        cache = DictCache({self.url: resp})
+        self.c.cache = cache
+        r = self.req({})
+        assert not r


### PR DESCRIPTION
I was working with a codebase that only sets last-modified and noticed that firefox would cache static resources but cachecontrol wouldn't. Investigating I turned up the last-modified heuristic in rfc7234 which "caches are encouraged to use". I hope it's acceptable and makes sense as default behavior.

This also addresses a problem where stale cache entries lacking an etag would be evicted, because those cached responses wouldn't be available for future requests using If-Modified-Since.

PEP8: ok. There was a preexisting long-line warning on line 257 and I left that alone.