### PR TITLE
Implement heuristic freshness based on Last-Modified

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@ Huge thanks to all those folks who have helped improve CacheControl!
  - Cory Benfield
  - Javier de la Rosa
  - Donald Stufft
+ - Joseph Walton

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -91,7 +91,7 @@ class LastModifiedHeuristic(BaseHeuristic):
         if 'expires' not in response.headers:
             if 'cache-control' not in response.headers or response.headers['cache-control'] == 'public':
                 # RFC 7231, 6.1
-                if response.status_code in [200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501]:
+                if response.status in [200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501]:
                     if 'last-modified' in response.headers:
                         last_modified = parsedate(response.headers['last-modified'])
                         now = datetime.now()

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -78,6 +78,8 @@ class ExpiresAfter(BaseHeuristic):
         tmpl = '110 - Automatically cached for %s. Response might be stale'
         return tmpl % self.delta
 
+ONE_DAY_IN_SECONDS = timedelta(days=1)
+
 class HeuristicFreshness(BaseHeuristic):
     """
     Apply the heuristic suggested by RFC 7234, 4.2.2
@@ -92,9 +94,7 @@ class HeuristicFreshness(BaseHeuristic):
                     if 'last-modified' in response.headers:
                         last_modified = parsedate(response.headers['last-modified'])
                         now = datetime.now()
-
                         age = now - datetime(*last_modified[:6])
-
                         expires = now + (age / 10)
 
                         return {'expires': datetime_to_header(expires)}
@@ -103,7 +103,7 @@ class HeuristicFreshness(BaseHeuristic):
     def warning(self, response):
         now = datetime.now()
         date = parsedate(response.headers['date'])
-        current_age = max(0, now - date)
+        current_age = max(timedelta(), now - datetime(*date[:6]))
 
         if current_age > ONE_DAY_IN_SECONDS:
             return '113 - Heuristic Expiration'

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -78,12 +78,13 @@ class ExpiresAfter(BaseHeuristic):
         tmpl = '110 - Automatically cached for %s. Response might be stale'
         return tmpl % self.delta
 
-ONE_DAY_IN_SECONDS = timedelta(days=1)
+_ONE_DAY_IN_SECONDS = timedelta(days=1)
 
-class HeuristicFreshness(BaseHeuristic):
+class LastModifiedHeuristic(BaseHeuristic):
     """
-    Apply the heuristic suggested by RFC 7234, 4.2.2
-    when no explicit freshness is specified.
+    Apply the heuristic suggested by RFC 7234, 4.2.2,
+    using the Last-Modified date, when no explicit
+    freshness is specified.
     """
 
     def update_headers(self, response):
@@ -105,7 +106,7 @@ class HeuristicFreshness(BaseHeuristic):
         date = parsedate(response.headers['date'])
         current_age = max(timedelta(), now - datetime(*date[:6]))
 
-        if current_age > ONE_DAY_IN_SECONDS:
+        if current_age > _ONE_DAY_IN_SECONDS:
             return '113 - Heuristic Expiration'
         else:
             return None

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -93,7 +93,7 @@ class HeuristicFreshness(BaseHeuristic):
                         last_modified = parsedate(response.headers['last-modified'])
                         now = datetime.now()
 
-                        age = now - last_modified
+                        age = now - datetime(*last_modified[:6])
 
                         expires = now + (age / 10)
 

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -36,9 +36,10 @@ class BaseHeuristic(object):
         return {}
 
     def apply(self, response):
-        warning_header = {'warning': self.warning(response)}
+        warning_header_value = self.warning(response)
         response.headers.update(self.update_headers(response))
-        response.headers.update(warning_header)
+        if warning_header_value is not None:
+            response.headers.update({'Warning': warning_header_value})
         return response
 
 

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -88,11 +88,13 @@ class LastModifiedHeuristic(BaseHeuristic):
     freshness is specified.
     """
 
+    def __init__(self):
+        self.cacheable_by_default_statuses = set([200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501])
+
     def update_headers(self, response):
         if 'expires' not in response.headers:
             if 'cache-control' not in response.headers or response.headers['cache-control'] == 'public':
-                # RFC 7231, 6.1
-                if response.status in [200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501]:
+                if response.status in self.cacheable_by_default_statuses:
                     if 'last-modified' in response.headers:
                         last_modified = parsedate(response.headers['last-modified'])
                         now = datetime.now()

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,13 @@
  Release Notes
 ===============
 
+0.12.0
+======
+
+This release introduces the `cachecontrol.heuristics.LastModifiedHeuristic`
+heuristic. This uses the same behaviour as many browsers to base expiry on the
+`Last-Modified` header when no explicit expiry is provided.
+
 0.11.0
 ======
 

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -65,8 +65,8 @@ from email.utils import formatdate, parsedate
 from datetime import datetime, timedelta
 
 class DummyResponse:
-    def __init__(self, status_code, headers):
-        self.status_code = status_code
+    def __init__(self, status, headers):
+        self.status = status
         self.headers = CaseInsensitiveDict(headers)
 
 def datetime_to_header(dt):

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -2,7 +2,7 @@ from mock import Mock
 
 from requests import Session, get
 from cachecontrol import CacheControl
-from cachecontrol.heuristics import OneDayCache, ExpiresAfter, HeuristicFreshness
+from cachecontrol.heuristics import OneDayCache, ExpiresAfter, LastModifiedHeuristic
 
 from pprint import pprint
 
@@ -72,9 +72,9 @@ class DummyResponse:
 def datetime_to_header(dt):
     return formatdate(calendar.timegm(dt.timetuple()))
 
-class TestHeuristicFreshness(object):
+class TestLastModifiedHeuristic(object):
     def setup(self):
-        self.heuristic = HeuristicFreshness()
+        self.heuristic = LastModifiedHeuristic()
 
     def test_no_expiry_is_inferred_when_no_last_modified_is_present(self):
         assert self.heuristic.update_headers(DummyResponse(200, {})) == {}


### PR DESCRIPTION
Implement the heuristic freshness calculation implied by RFC 7234, and used by many browsers, of ten percent of the resource's age when there is a `Last-Modified` header but no explicit freshness.