### PR TITLE
Fix a couple of edge cases with the LastModified heuristic

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@ Huge thanks to all those folks who have helped improve CacheControl!
  - Cory Benfield
  - Javier de la Rosa
  - Donald Stufft
+ - Joseph Walton

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -95,9 +95,16 @@ class LastModified(BaseHeuristic):
     http://lxr.mozilla.org/mozilla-release/source/netwerk/protocol/http/nsHttpResponseHead.cpp#397
     Unlike mozilla we limit this to 24-hr.
     """
+    cacheable_by_default_statuses = set([200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501])
 
     def update_headers(self, resp):
         if 'expires' in resp.headers:
+            return {}
+
+        if 'cache-control' in resp.headers and resp.headers['cache-control'] != 'public':
+            return {}
+
+        if resp.status not in self.cacheable_by_default_statuses:
             return {}
 
         if 'date' not in resp.headers or 'last-modified' not in resp.headers:

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -39,9 +39,10 @@ class BaseHeuristic(object):
         return {}
 
     def apply(self, response):
-        warning_header = {'warning': self.warning(response)}
+        warning_header_value = self.warning(response)
         response.headers.update(self.update_headers(response))
-        response.headers.update(warning_header)
+        if warning_header_value is not None:
+            response.headers.update({'Warning': warning_header_value})
         return response
 
 
@@ -94,7 +95,6 @@ class LastModified(BaseHeuristic):
     http://lxr.mozilla.org/mozilla-release/source/netwerk/protocol/http/nsHttpResponseHead.cpp#397
     Unlike mozilla we limit this to 24-hr.
     """
-    date = None
 
     def update_headers(self, resp):
         if 'expires' in resp.headers:
@@ -115,11 +115,10 @@ class LastModified(BaseHeuristic):
         if freshness_lifetime <= current_age:
             return {}
 
-        self.date = time.strftime(TIME_FMT, last_modified)
         expires = date + freshness_lifetime
         return {'expires': time.strftime(TIME_FMT, time.gmtime(expires))}
 
     def warning(self, resp):
-        return '110 - "Response may be stale, last modified %s"' % self.date
+        return None
 
 # heuristics.py

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,13 @@
  Release Notes
 ===============
 
+0.12.0
+======
+
+This release introduces the `cachecontrol.heuristics.LastModified`
+heuristic. This uses the same behaviour as many browsers to base expiry on the
+`Last-Modified` header when no explicit expiry is provided.
+
 0.11.0
 ======
 

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -72,7 +72,7 @@ class TestLastModified(object):
         r = self.sess.get(the_url)
 
         assert 'expires' in r.headers
-        assert 'warning' in r.headers
+        assert 'warning' not in r.headers
 
         pprint(dict(r.headers))
 

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -59,7 +59,6 @@ class TestExpiresAfter(object):
         r = self.sess.get(the_url)
         assert r.from_cache
 
-
 class TestLastModified(object):
 
     def setup(self):
@@ -80,5 +79,72 @@ class TestLastModified(object):
         r = self.sess.get(the_url)
         pprint(dict(r.headers))
         assert r.from_cache
+
+import calendar
+import time
+from requests.structures import CaseInsensitiveDict
+from email.utils import formatdate, parsedate
+from datetime import datetime, timedelta
+
+TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
+
+class DummyResponse:
+    def __init__(self, status, headers):
+        self.status = status
+        self.headers = CaseInsensitiveDict(headers)
+
+def datetime_to_header(dt):
+    return formatdate(calendar.timegm(dt.timetuple()))
+
+class TestModifiedUnitTests(object):
+    def setup(self):
+        self.heuristic = LastModified()
+        time_now = time.time()
+        self.year_ago = time.strftime(TIME_FMT, time.gmtime(time_now - (86400 * 365)))
+        self.week_ago = time.strftime(TIME_FMT, time.gmtime(time_now - (86400 * 7)))
+        self.day_ago = time.strftime(TIME_FMT, time.gmtime(time_now - 86400))
+        self.now = time.strftime(TIME_FMT, time.gmtime(time_now))
+        self.day_ahead = time.strftime(TIME_FMT, time.gmtime(time_now + 86400))
+
+    def test_no_expiry_is_inferred_when_no_last_modified_is_present(self):
+        assert self.heuristic.update_headers(DummyResponse(200, {})) == {}
+
+    def test_expires_is_not_replaced_when_present(self):
+        resp = DummyResponse(200, {'Expires': self.day_ahead})
+        assert self.heuristic.update_headers(resp) == {}
+
+    def test_last_modified_is_used(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Last-Modified': self.week_ago})
+        modified = self.heuristic.update_headers(resp)
+        assert ['expires'] == list(modified.keys())
+        assert datetime(*parsedate(modified['expires'])[:6]) > datetime.now()
+
+    def test_last_modified_is_not_used_when_cache_control_present(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Last-Modified': self.week_ago, 'Cache-Control': 'private'})
+        assert self.heuristic.update_headers(resp) == {}
+
+    def test_last_modified_is_not_used_when_status_is_unknown(self):
+        resp = DummyResponse(299, {'Date': self.now, 'Last-Modified': self.week_ago})
+        assert self.heuristic.update_headers(resp) == {}
+
+    def test_last_modified_is_used_when_cache_control_public(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Last-Modified': self.week_ago, 'Cache-Control': 'public'})
+        modified = self.heuristic.update_headers(resp)
+        assert ['expires'] == list(modified.keys())
+        assert datetime(*parsedate(modified['expires'])[:6]) > datetime.now()
+
+    def test_warning_is_not_added_when_response_more_recent_than_24_hours(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Last-Modified': self.week_ago})
+        assert self.heuristic.warning(resp) is None
+
+    def test_warning_is_not_added_when_heuristic_was_not_used(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Expires': self.day_ahead})
+        assert self.heuristic.warning(resp) is None
+
+    def test_expiry_is_no_more_that_twenty_four_hours(self):
+        resp = DummyResponse(200, {'Date': self.now, 'Last-Modified': self.year_ago})
+        modified = self.heuristic.update_headers(resp)
+        assert ['expires'] == list(modified.keys())
+        assert self.day_ahead == modified['expires']
 
 # test_expires_heuristics.py


### PR DESCRIPTION
#62 introduced a new LastModified heuristic, very similar to the one I proposed in #61, but avoiding the issue with warnings needing to be dynamic. This change carries across a couple of edge cases and a set of unit tests to work with the merged version.