### PR TITLE
Fix KeyError if cached response has no date header

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -117,6 +117,12 @@ class CacheController(object):
             return resp
 
         headers = CaseInsensitiveDict(resp.headers)
+        if not headers or 'date' not in headers:
+            # With date or etag, the cached response can never be used
+            # and should be deleted.
+            if 'etag' not in headers:
+                self.cache.delete(cache_url)
+            return False
 
         now = time.time()
         date = calendar.timegm(

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -128,6 +128,12 @@ class TestCacheControlRequest(object):
     def req(self, headers):
         return self.c.cached_request(Mock(url=self.url, headers=headers))
 
+    def test_cache_request_no_headers(self):
+        cached_resp = Mock(headers={'ETag': 'jfd9094r808', 'Content-Length': 100})
+        self.c.cache = DictCache({self.url: cached_resp})
+        resp = self.req({})
+        assert not resp
+
     def test_cache_request_no_cache(self):
         resp = self.req({'cache-control': 'no-cache'})
         assert not resp


### PR DESCRIPTION
This fixes errors like the following, which can happen if the cached response has no `Date` header:

    $ pip install pdb
    Collecting pdb
      Using cached pdb-0.1.tar.gz
    Collecting python-gnupg (from pdb)
      Using cached python-gnupg-0.3.7.tar.gz
    Collecting argparse (from pdb)
      Exception:
      Traceback (most recent call last):
        ...
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/download.py", line 859, in _download_http_url
          stream=True,
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/requests/sessions.py", line 476, in get
          return self.request('GET', url, **kwargs)
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/download.py", line 367, in request
          return super(PipSession, self).request(method, url, *args, **kwargs)
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/requests/sessions.py", line 464, in request
          resp = self.send(prep, **send_kwargs)
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/requests/sessions.py", line 576, in send
          r = adapter.send(request, **kwargs)
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/cachecontrol/adapter.py", line 36, in send
          cached_response = self.controller.cached_request(request)
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/cachecontrol/controller.py", line 110, in cached_request
          parsedate_tz(headers['date'])
        File "/Users/marca/dev/git-repos/pip/.tox/py27/lib/python2.7/site-packages/pip/_vendor/requests/structures.py", line 54, in __getitem__
          return self._store[key.lower()][1]
      KeyError: 'date'

Cc: @alex, @dstufft 