### PR TITLE
Split one line in two; to make pdb easier

### DIFF
--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -126,7 +126,8 @@ class TestCacheControlRequest(object):
         )
 
     def req(self, headers):
-        return self.c.cached_request(Mock(url=self.url, headers=headers))
+        mock_request = Mock(url=self.url, headers=headers)
+        return self.c.cached_request(mock_request)
 
     def test_cache_request_no_cache(self):
         resp = self.req({'cache-control': 'no-cache'})


### PR DESCRIPTION
With Mock stuff and cached_request on one line, it is difficult to step
into cached_requests without getting stuck in the innards of mock.