### PR TITLE
tox.ini: Add more envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
 deps = pytest
@@ -7,4 +7,4 @@ deps = pytest
        webtest
        redis
        lockfile
-commands = py.test
+commands = py.test {posargs:tests/}


### PR DESCRIPTION
to match .travis.yml. Also only looks for tests in tests/ directory but
allow overriding things with tox {posargs} feature.