### PR TITLE
Check for valid max-age in responses

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -280,7 +280,7 @@ class CacheController(object):
         elif 'date' in response_headers:
             # cache when there is a max-age > 0
             if cc and cc.get('max-age'):
-                if int(cc['max-age']) > 0:
+                if cc['max-age'].isdigit() and int(cc['max-age']) > 0:
                     logger.debug('Caching b/c date exists and max-age > 0')
                     self.cache.set(
                         cache_url,

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -84,6 +84,7 @@ class TestCacheControllerResponse(object):
 
     def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):
         now = time.strftime(TIME_FMT, time.gmtime())
+        # Not a valid header; this would be from a misconfigured server
         resp = self.resp({'cache-control': 'max-age=3600; public',
                           'date': now})
         cc.cache_response(self.req(), resp)
@@ -206,6 +207,7 @@ class TestCacheControlRequest(object):
 
     def test_cached_request_with_bad_max_age_headers_not_returned(self):
         now = time.strftime(TIME_FMT, time.gmtime())
+        # Not a valid header; this would be from a misconfigured server
         resp = Mock(headers={'cache-control': 'max-age=xxx',
                              'date': now})
 

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -82,7 +82,15 @@ class TestCacheControllerResponse(object):
         cc.serializer.dumps.assert_called_with(req, resp, body=None)
         cc.cache.set.assert_called_with(self.url, ANY)
 
-    def test_cache_repsonse_no_store(self):
+    def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):
+        now = time.strftime(TIME_FMT, time.gmtime())
+        resp = self.resp({'cache-control': 'max-age=3600; public',
+                          'date': now})
+        cc.cache_response(self.req(), resp)
+
+        assert not cc.cache.set.called
+
+    def test_cache_response_no_store(self):
         resp = Mock()
         cache = DictCache({self.url: resp})
         cc = CacheController(cache)

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -195,3 +195,12 @@ class TestCacheControlRequest(object):
         self.c.cache = cache
         r = self.req({})
         assert not r
+
+    def test_cached_request_with_bad_max_age_headers_not_returned(self):
+        now = time.strftime(TIME_FMT, time.gmtime())
+        resp = Mock(headers={'cache-control': 'max-age=xxx',
+                             'date': now})
+
+        self.c.cache = DictCache({self.url: resp})
+
+        assert not self.req({})


### PR DESCRIPTION
Motivated by seeing:

    Cache-Control: max-age=900; public

(with a semicolon, rather than a comma) in the wild. It's invalid, but shouldn't cause an error. Right now, this fails with an exception. Fix it, and add a corresponding test when retrieving from the cache, to confirm that that case already checks.