### PR TITLE
Implementing caching of chunked/streamed responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 env:
  - TOXENV=py26

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -99,13 +99,13 @@ class CacheControlAdapter(HTTPAdapter):
                     )
                 )
                 if response.chunked:
-                    original_update_chunk_length = response._update_chunk_length
+                    super_update_chunk_length = response._update_chunk_length
+
                     def _update_chunk_length(self):
-                        original_update_chunk_length()
+                        super_update_chunk_length()
                         if self.chunk_left == 0:
                             self._fp._close()
                     response._update_chunk_length = types.MethodType(_update_chunk_length, response)
-
 
         resp = super(CacheControlAdapter, self).build_response(
             request, response

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -1,3 +1,4 @@
+import types
 import functools
 
 from requests.adapters import HTTPAdapter
@@ -97,6 +98,14 @@ class CacheControlAdapter(HTTPAdapter):
                         response,
                     )
                 )
+                if response.chunked:
+                    original_update_chunk_length = response._update_chunk_length
+                    def _update_chunk_length(self):
+                        original_update_chunk_length()
+                        if self.chunk_left == 0:
+                            self._fp._close()
+                    response._update_chunk_length = types.MethodType(_update_chunk_length, response)
+
 
         resp = super(CacheControlAdapter, self).build_response(
             request, response

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -134,6 +134,12 @@ class Serializer(object):
 
         body_raw = cached["response"].pop("body")
 
+        headers = CaseInsensitiveDict(data=cached['response']['headers'])
+        if headers.get('transfer-encoding', '') == 'chunked':
+            headers.pop('transfer-encoding')
+
+        cached['response']['headers'] = headers
+
         try:
             body = io.BytesIO(body_raw)
         except TypeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,14 @@ class SimpleApp(object):
         start_response('300 Multiple Choices', headers)
         return ['See: /permalink'.encode('utf-8')]
 
+    def stream(self, env, start_response):
+        headers = [
+            ('Cache-Control', 'max-age=5000'),
+            ('Content-Type', 'text/plain'),
+        ]
+        start_response('200 OK', headers)
+        return (pformat(env).encode("utf8") for i in range(10))
+
     def __call__(self, env, start_response):
         func = self.dispatch(env)
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,23 @@
+"""
+Test for supporting streamed responses (Transfer-Encoding: chunked)
+"""
+import requests
+
+from cachecontrol import CacheControl
+
+
+class TestStream(object):
+
+    def setup(self):
+        self.sess = CacheControl(requests.Session())
+
+    def test_stream_is_cached(self, url):
+        resp_1 = self.sess.get(url + 'stream')
+        content_1 = resp_1.content
+
+        resp_2 = self.sess.get(url + 'stream')
+        content_2  = resp_1.content
+
+        assert not resp_1.from_cache
+        assert resp_2.from_cache
+        assert content_1 == content_2

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -7,16 +7,22 @@ from cachecontrol import CacheControl
 
 
 class TestStream(object):
-    def setup(self):
-        self.sess = CacheControl(requests.Session())
-
     def test_stream_is_cached(self, url):
-        resp_1 = self.sess.get(url + 'stream')
+        sess = CacheControl(requests.Session())
+
+        resp_1 = sess.get(url + 'stream')
         content_1 = resp_1.content
 
-        resp_2 = self.sess.get(url + 'stream')
+        resp_2 = sess.get(url + 'stream')
         content_2 = resp_1.content
 
         assert not resp_1.from_cache
         assert resp_2.from_cache
         assert content_1 == content_2
+
+    def test_stream_is_not_cached_when_content_is_not_read(self, url):
+        sess = CacheControl(requests.Session())
+        sess.get(url + 'stream', stream=True)
+        resp = sess.get(url + 'stream', stream=True)
+
+        assert not resp.from_cache

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -15,7 +15,7 @@ class TestStream(object):
         content_1 = resp_1.content
 
         resp_2 = self.sess.get(url + 'stream')
-        content_2  = resp_1.content
+        content_2 = resp_1.content
 
         assert not resp_1.from_cache
         assert resp_2.from_cache

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -7,7 +7,6 @@ from cachecontrol import CacheControl
 
 
 class TestStream(object):
-
     def setup(self):
         self.sess = CacheControl(requests.Session())
 


### PR DESCRIPTION
Resolves #105, #81. This takes a different approach from #82 in that it doesn't get rid of `CallbackFileWrapper`, so there is still the same delay actually caching the response until the calling application itself reads the data.

On the other hand, this requires dynamically monkeypatching urllib3, so ¯\_(ツ)_/¯.