### PR TITLE
Fix crash when FileCache.delete() is called on non-existing file.

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -104,7 +104,10 @@ class FileCache(BaseCache):
     def delete(self, key):
         name = self._fn(key)
         if not self.forever:
-            os.remove(name)
+            try:
+                os.remove(name)
+            except FileNotFoundError:
+                pass
 
 
 def url_to_file_path(url, filecache):


### PR DESCRIPTION
In certain cases, FileCache.delete() can be called on a non-existing file. In my case it happens when performing a PUT on a URL that we didn't GET beforehand. My test script is below, but it is highly application-dependent:

``` python
#!python3

import requests
import cachecontrol
from cachecontrol.caches import FileCache

session = cachecontrol.CacheControl(sess=requests.session(),
                                    cache=FileCache('./demo-cache'))

etag = 'c9e82759883db8f8c00842ee4cfcd9824cd55407'
URL = 'http://localhost:5000/nodes/5763ea748badee551aff00b3'

node = {
    'description': 'Victor, from Cosmos Laundromat, with updated BlenRig.',
    'name': 'Victor',
    'node_type': 'asset',
    'project': '5763d9038badee551aff0045',
    'properties': {'categories': '',
                   'content_type': 'file',
                   'file': '5763d9068badee551aff0048',
                   'order': 0,
                   'status': 'published',
                   'tags': ['']},
    'user': '5755a0478badee23c7efd3d9'
}

response = session.request('PUT', URL,
                           headers={'Content-Type': 'application/json',
                                    'If-Match': etag},
                           auth=('mysecrettoken', ''),
                           json=node)
print(response.status_code)
```

My proposed fix is fairly simple, though.
