### PR TITLE
use tool:pytest in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = bin lib include build


### PR DESCRIPTION
Running tox, I get an error message about using tool:pytest in the setup.cfg file. This PR is also (and mostly) an excuse to fire a Travis build. Tests are now [passing for me with Travis](https://travis-ci.org/eads/cachecontrol/jobs/157548834).