### PR TITLE
Ignore corrupted caches

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -174,7 +174,7 @@ class Serializer(object):
     def _loads_v2(self, request, data):
         try:
             cached = json.loads(zlib.decompress(data).decode("utf8"))
-        except ValueError:
+        except (ValueError, zlib.error):
             return
 
         # We need to decode the items that we've base64 encoded

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -60,6 +60,11 @@ class TestSerializer(object):
         # string.
         assert resp.data == 'Hello World'.encode('utf-8')
 
+    def test_read_v2_corrupted_cache(self):
+        # This should prevent a regression of bug #134
+        req = Mock()
+        assert self.serializer._loads_v2(req, b'') is None
+
     def test_read_version_three_streamable(self, url):
         original_resp = requests.get(url, stream=True)
         req = original_resp.request


### PR DESCRIPTION
Previously it was possible for a cache's compressed data to become
corrupted and cause an unhandled exception. Handling zlib.error in the
Serializer allows for the cachecontrol adapter to make a request if a
cache has been corrupted.

Closes #134

-- 

**Note** This might not pass Travis CI because of a new version of Requests that changed some expectations about how Response objects work. I'm going to work on a separate PR for that.