### PR TITLE
Update NullSerializer to force chunked off

### DIFF
--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -15,6 +15,8 @@ class NullSerializer(object):
         return response
 
     def loads(self, request, data):
+        if data and getattr(data, 'chunked', False):
+            data.chunked = False
         return data
 
 

--- a/tests/test_max_age.py
+++ b/tests/test_max_age.py
@@ -12,6 +12,8 @@ class NullSerializer(object):
         return response
 
     def loads(self, request, data):
+        if data and getattr(data, 'chunked', False):
+            data.chunked = False
         return data
 
 


### PR DESCRIPTION
With more recent versions of Requests (2.11ish and newer) we need to
force chunked handling off even in our NullSerializer.

This should fix the tests on #135