### PR TITLE
Fix key expiration for redis

### DIFF
--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -6,11 +6,11 @@ from datetime import datetime
 def total_seconds(td):
     """Python 2.6 compatability"""
     if hasattr(td, 'total_seconds'):
-        return td.total_seconds()
+        return int(td.total_seconds())
 
     ms = td.microseconds
     secs = (td.seconds + td.days * 24 * 3600)
-    return (ms + secs * 10**6) / 10**6
+    return int((ms + secs * 10**6) / 10**6)
 
 
 class RedisCache(object):


### PR DESCRIPTION
This PR fixes problems when using the `RedisCache`.

Storing a key with an expiration date would result in the error `redis.exceptions.ResponseError: value is not an integer or out of range` as the expiration time (in seconds) was passed as a float while redis expected an integer. 