### PR TITLE
FileNotFoundError fallback for 2.X

### DIFF
--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -5,6 +5,12 @@ from textwrap import dedent
 from ..cache import BaseCache
 from ..controller import CacheController
 
+try:
+    FileNotFoundError
+except NameError:
+    # py2.X
+    FileNotFoundError = IOError
+
 
 def _secure_open_write(filename, fmode):
     # We only want to write to this file, so open it in write only mode


### PR DESCRIPTION
This maintains compatibility for Python 2.X. Also see https://github.com/pypa/pip/issues/4322.