### PR TITLE
Make CacheControl, CacheControlAdapter and CacheControler easier to customize

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -28,12 +28,12 @@ class CacheControlAdapter(HTTPAdapter):
             serializer=serializer,
         )
 
-    def send(self, request, **kw):
+    def send(self, request, cacheable=('GET',), **kw):
         """
         Send a request. Use the request information to see if it
         exists in the cache and cache the response if we need to and can.
         """
-        if request.method == 'GET':
+        if request.method in cacheable:
             cached_response = self.controller.cached_request(request)
             if cached_response:
                 return self.build_response(request, cached_response,
@@ -48,14 +48,15 @@ class CacheControlAdapter(HTTPAdapter):
 
         return resp
 
-    def build_response(self, request, response, from_cache=False):
+    def build_response(self, request, response, from_cache=False,
+                       cacheable=('GET',)):
         """
         Build a response by making a request or using the cache.
 
         This will end up calling send and returning a potentially
         cached response
         """
-        if not from_cache and request.method == 'GET':
+        if not from_cache and request.method in cacheable:
             # Check for any heuristics that might update headers
             # before trying to cache.
             if self.heuristic:

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -16,10 +16,12 @@ class CacheControlAdapter(HTTPAdapter):
                  controller_class=None,
                  serializer=None,
                  heuristic=None,
+                 cacheable_methods=None,
                  *args, **kw):
         super(CacheControlAdapter, self).__init__(*args, **kw)
         self.cache = cache or DictCache()
         self.heuristic = heuristic
+        self.cacheable_methods = cacheable_methods or ('GET',)
 
         controller_factory = controller_class or CacheController
         self.controller = controller_factory(
@@ -28,11 +30,12 @@ class CacheControlAdapter(HTTPAdapter):
             serializer=serializer,
         )
 
-    def send(self, request, cacheable=('GET',), **kw):
+    def send(self, request, cacheable_methods=None, **kw):
         """
         Send a request. Use the request information to see if it
         exists in the cache and cache the response if we need to and can.
         """
+        cacheable = cacheable_methods or self.cacheable_methods
         if request.method in cacheable:
             cached_response = self.controller.cached_request(request)
             if cached_response:
@@ -49,13 +52,14 @@ class CacheControlAdapter(HTTPAdapter):
         return resp
 
     def build_response(self, request, response, from_cache=False,
-                       cacheable=('GET',)):
+                       cacheable_methods=None):
         """
         Build a response by making a request or using the cache.
 
         This will end up calling send and returning a potentially
         cached response
         """
+        cacheable = cacheable_methods or self.cacheable_methods
         if not from_cache and request.method in cacheable:
             # Check for any heuristics that might update headers
             # before trying to cache.

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -220,7 +220,8 @@ class CacheController(object):
 
         return new_headers
 
-    def cache_response(self, request, response, body=None):
+    def cache_response(self, request, response, body=None,
+                       cacheable_status_codes=None):
         """
         Algorithm for caching requests.
 
@@ -228,7 +229,7 @@ class CacheController(object):
         """
         # From httplib2: Don't cache 206's since we aren't going to
         #                handle byte range requests
-        cacheable_status_codes = [200, 203, 300, 301]
+        cacheable_status_codes = cacheable_status_codes or (200, 203, 300, 301)
         if response.status not in cacheable_status_codes:
             logger.debug(
                 'Status code %s not in %s',

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -30,10 +30,12 @@ def parse_uri(uri):
 class CacheController(object):
     """An interface to see if request should cached or not.
     """
-    def __init__(self, cache=None, cache_etags=True, serializer=None):
+    def __init__(self, cache=None, cache_etags=True, serializer=None,
+                 status_codes=None):
         self.cache = cache or DictCache()
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
+        self.cacheable_status_codes = status_codes or (200, 203, 300, 301)
 
     @classmethod
     def _urlnorm(cls, uri):
@@ -221,7 +223,7 @@ class CacheController(object):
         return new_headers
 
     def cache_response(self, request, response, body=None,
-                       cacheable_status_codes=None):
+                       status_codes=None):
         """
         Algorithm for caching requests.
 
@@ -229,7 +231,7 @@ class CacheController(object):
         """
         # From httplib2: Don't cache 206's since we aren't going to
         #                handle byte range requests
-        cacheable_status_codes = cacheable_status_codes or (200, 203, 300, 301)
+        cacheable_status_codes = status_codes or self.cacheable_status_codes
         if response.status not in cacheable_status_codes:
             logger.debug(
                 'Status code %s not in %s',

--- a/cachecontrol/wrapper.py
+++ b/cachecontrol/wrapper.py
@@ -8,7 +8,8 @@ def CacheControl(sess,
                  serializer=None,
                  heuristic=None,
                  controller_class=None,
-                 adapter_class=None):
+                 adapter_class=None,
+                 cacheable_methods=None):
 
     cache = cache or DictCache()
     adapter_class = adapter_class or CacheControlAdapter
@@ -17,7 +18,8 @@ def CacheControl(sess,
         cache_etags=cache_etags,
         serializer=serializer,
         heuristic=heuristic,
-        controller_class=controller_class
+        controller_class=controller_class,
+        cacheable_methods=cacheable_methods
     )
     sess.mount('http://', adapter)
     sess.mount('https://', adapter)

--- a/cachecontrol/wrapper.py
+++ b/cachecontrol/wrapper.py
@@ -6,14 +6,18 @@ def CacheControl(sess,
                  cache=None,
                  cache_etags=True,
                  serializer=None,
-                 heuristic=None):
+                 heuristic=None,
+                 controller_class=None,
+                 adapter_class=None):
 
     cache = cache or DictCache()
-    adapter = CacheControlAdapter(
+    adapter_class = adapter_class or CacheControlAdapter
+    adapter = adapter_class(
         cache,
         cache_etags=cache_etags,
         serializer=serializer,
         heuristic=heuristic,
+        controller_class=controller_class
     )
     sess.mount('http://', adapter)
     sess.mount('https://', adapter)


### PR DESCRIPTION
This PR allow easily overriding what methods and status codes should be cacheable. It allows writing 'full local mirror' code (caching POSTs, 403, 404, etc.) in about 10 lines and should be harmless when not in use (tests pass).