### PR TITLE
Correctly handle cached shared between Py2 and Py3

### DIFF
--- a/cachecontrol/compat.py
+++ b/cachecontrol/compat.py
@@ -24,6 +24,6 @@ except ImportError:
 
 # Replicate some six behaviour
 try:
-    text_type = (unicode,)
+    text_type = unicode
 except NameError:
-    text_type = (str,)
+    text_type = str

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -6,7 +6,7 @@ import zlib
 import msgpack
 from requests.structures import CaseInsensitiveDict
 
-from .compat import HTTPResponse, pickle
+from .compat import HTTPResponse, pickle, text_type
 
 
 def _b64_decode_bytes(b):
@@ -37,27 +37,40 @@ class Serializer(object):
             #       `Serializer.dump`.
             response._fp = io.BytesIO(body)
 
+        # NOTE: This is all a bit weird, but it's really important that on
+        #       Python 2.x these objects are unicode and not str, even when
+        #       they contain only ascii. The problem here is that msgpack
+        #       understands the difference between unicode and bytes and we
+        #       have it set to differentiate between them, however Python 2
+        #       doesn't know the difference. Forcing these to unicode will be
+        #       enough to have msgpack know the difference.
         data = {
-            "response": {
-                "body": body,
-                "headers": dict(response.headers),
-                "status": response.status,
-                "version": response.version,
-                "reason": response.reason,
-                "strict": response.strict,
-                "decode_content": response.decode_content,
+            u"response": {
+                u"body": body,
+                u"headers": dict(
+                    (text_type(k), text_type(v))
+                    for k, v in response.headers.items()
+                ),
+                u"status": response.status,
+                u"version": response.version,
+                u"reason": text_type(response.reason),
+                u"strict": response.strict,
+                u"decode_content": response.decode_content,
             },
         }
 
         # Construct our vary headers
-        data["vary"] = {}
-        if "vary" in response_headers:
-            varied_headers = response_headers['vary'].split(',')
+        data[u"vary"] = {}
+        if u"vary" in response_headers:
+            varied_headers = response_headers[u'vary'].split(',')
             for header in varied_headers:
                 header = header.strip()
-                data["vary"][header] = request.headers.get(header, None)
+                header_value = request.headers.get(header, None)
+                if header_value is not None:
+                    header_value = text_type(header_value)
+                data[u"vary"][header] = header_value
 
-        return b",".join([b"cc=3", msgpack.dumps(data, use_bin_type=True)])
+        return b",".join([b"cc=4", msgpack.dumps(data, use_bin_type=True)])
 
     def loads(self, request, data):
         # Short circuit if we've been given an empty set of data
@@ -167,6 +180,12 @@ class Serializer(object):
         return self.prepare_response(request, cached)
 
     def _loads_v3(self, request, data):
+        # Due to Python 2 encoding issues, it's impossible to know for sure
+        # exactly how to load v3 entries, thus we'll treat these as a miss so
+        # that they get rewritten out as v4 entries.
+        return
+
+    def _loads_v4(self, request, data):
         try:
             cached = msgpack.loads(data, encoding='utf-8')
         except ValueError:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,20 +12,20 @@ class TestSerializer(object):
     def setup(self):
         self.serializer = Serializer()
         self.response_data = {
-            'response': {
+            u'response': {
                 # Encode the body as bytes b/c it will eventually be
                 # converted back into a BytesIO object.
-                'body': 'Hello World'.encode('utf-8'),
-                'headers': {
-                    'Content-Type': 'text/plain',
-                    'Expires': '87654',
-                    'Cache-Control': 'public',
+                u'body': 'Hello World'.encode('utf-8'),
+                u'headers': {
+                    u'Content-Type': u'text/plain',
+                    u'Expires': u'87654',
+                    u'Cache-Control': u'public',
                 },
-                'status': 200,
-                'version': '2',
-                'reason': '',
-                'strict': '',
-                'decode_content': True,
+                u'status': 200,
+                u'version': 11,
+                u'reason': u'',
+                u'strict': True,
+                u'decode_content': True,
             },
         }
 
@@ -48,9 +48,15 @@ class TestSerializer(object):
         # We have to decode our urllib3 data back into a unicode string.
         assert resp.data == 'Hello World'.encode('utf-8')
 
-    def test_read_version_v3(self):
+    def test_load_by_version_v3(self):
+        data = b'cc=3,somedata'
         req = Mock()
-        resp = self.serializer._loads_v3(req, msgpack.dumps(self.response_data))
+        resp = self.serializer.loads(req, data)
+        assert resp is None
+
+    def test_read_version_v4(self):
+        req = Mock()
+        resp = self.serializer._loads_v4(req, msgpack.dumps(self.response_data))
         # We have to decode our urllib3 data back into a unicode string.
         assert resp.data == 'Hello World'.encode('utf-8')
 
@@ -120,4 +126,3 @@ class TestSerializer(object):
                 body=data
             )
         )
-


### PR DESCRIPTION
This issue a bit subtle, but essentially msgpack (the way it's being used here) has a Python3 like model with a strict split between bytes and text. This is a generally a good thing, HOWEVER it plays havoc when you're *creating* a cached file on Python 2.x and *consuming* it on Python 3.x. This is because the ``str`` type is both text and bytes on 2.x, so msgpack makes the assumption that ``str``/``bytes`` is binary data and ``unicode`` is textual data.

This all ends up meaning that serializing something like ``{"response": ...}`` on Python 2 ends up getting serialized the same as ``{b"response": ...}`` on Python 3. This causes things to blow up when attempting to load a cached entry serialized by Python 2 on Python 3, because it's is essentially doing this: ``{b"response": ...}[u"response"]``.

Thus what this patch does is force even ASCII text to be unicode when serializing out the data, which will cause msgpack to write them as the str type and all will be well. Because we can only infer (and we can't *know*) what the correct type was for already cached v3 entries, I went ahead and made v3 entries a miss and moved the cache entries onto v4.

This also includes a tweak to ``text_type`` to make it match the behavior of six better. Nothing appears to be currently using that so it should not break anything.