### PR TITLE
Close CallbackFileWrapper.__buf once it's used to free memory.

### DIFF
--- a/cachecontrol/filewrapper.py
+++ b/cachecontrol/filewrapper.py
@@ -56,9 +56,16 @@ class CallbackFileWrapper(object):
         # and allows the garbage collector to do it's thing normally.
         self.__callback = None
 
+        # Closing the BytesIO stream releases memory. Important when caching
+        # big files.
+        self.__buf.close()
+
     def read(self, amt=None):
         data = self.__fp.read(amt)
-        self.__buf.write(data)
+        if data:
+            # We may be dealing with b'', a sign that things are over:
+            # it's passed e.g. after we've already closed self.__buf.
+            self.__buf.write(data)
         if self.__is_fp_closed():
             self._close()
 


### PR DESCRIPTION
This tries to solve #145. It seems like `CallbackFileWrapper.__buf` is keeping its stream after we're done with it, and it unnecessarily bloats the process.

Running the script at the end (and [attached](https://github.com/ionrock/cachecontrol/files/915156/test_memory.txt)) against a 74 MB file I get...

For original code:
> Using **106 MB** on program end.
> Mean memory use: **199 MB**

For both patched code and bare requests:
> Using **32 MB** on program end.
> Mean memory use: **32 MB**

(These numbers are on Windows, Python 3.4.2 32-bits)

```python
import os
import logging
import shutil

import requests
import cachecontrol
import psutil

# logging.basicConfig(level=logging.DEBUG)

us = psutil.Process(os.getpid())
MB = 1024 * 1024
N = 15

sess = cachecontrol.CacheControl(requests.Session())

total = 0
for i in range(N):
    url = 'http://localhost:8000/bigdata.bin?limit=%s' % i
    print('Requesting %s...' % i)
    response = sess.get(url, stream=True)
    fh = open('dest.bin', 'wb')
    shutil.copyfileobj(response.raw, fh)
    fh.close()
    used_mem = us.memory_full_info().uss / MB
    total += used_mem
    print('Using %d MB.' % round(used_mem))

import gc
gc.collect()

print('Done.')
print('Using %d MB on program end.' % round(us.memory_full_info().uss / MB))
print('Mean memory use: %d MB' % round(total/N))
input()
```