### PR TITLE
Redis backend connection fix

### DIFF
--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 from datetime import datetime
+from cachecontrol.cache import BaseCache
 
 
 def total_seconds(td):
@@ -13,7 +14,7 @@ def total_seconds(td):
     return int((ms + secs * 10**6) / 10**6)
 
 
-class RedisCache(object):
+class RedisCache(BaseCache):
 
     def __init__(self, conn):
         self.conn = conn

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -39,4 +39,5 @@ class RedisCache(BaseCache):
             self.conn.delete(key)
 
     def close(self):
-        self.conn.disconnect()
+        """Redis uses connection pooling, no need to close the connection."""
+        pass


### PR DESCRIPTION
Sorry again about my messing about with unrelated commits, this is a copy of the previous PR with the correct commits this time!

Hi!

As mentioned yesterday in #149, I found some problems with cachecontrol attempting to close the connection to redis when .close is called on the cache adapter, causing issues because the `Redis` object doesn't have a disconnect method.

I'm not an expert on redis, but as far as I can tell py-redis uses connection pooling by default, making it unnecessary to explicitly close connections (source: http://stackoverflow.com/questions/24875806/redis-in-python-how-do-you-close-the-connection)

I've coded up a quick fix that simply doesn't do anything when closing a redis cache, which I _think_ is the correct behaviour. There might be cases where a user manages to instantiate redis without a connection pool, in which case closing the connection might be necessary, but I don't even know how to do that, so I'm hoping we can shelve that potential problem for now.

For reference, here's a quick example of code I've been using that caused problems for me with the original behaviour:

```python
@contextmanager
def cache_session(session=None):
    """Context manager to easily apply caching to a session.

    An existing session can be passed in, otherwise
    a new Session is created.
    """

    session = session if session else Session()
    session.mount('http://', cache_adapter)
    session.mount('https://', cache_adapter)

    yield session
```