### PR TITLE
Use datetime.utcnow to be consistent with other headers

### DIFF
--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -25,7 +25,7 @@ class RedisCache(object):
         if not expires:
             self.conn.set(key, value)
         else:
-            expires = expires - datetime.now()
+            expires = expires - datetime.utcnow()
             self.conn.setex(key, total_seconds(expires), value)
 
     def delete(self, key):

--- a/cachecontrol/heuristics.py
+++ b/cachecontrol/heuristics.py
@@ -9,7 +9,7 @@ TIME_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
 def expire_after(delta, date=None):
-    date = date or datetime.now()
+    date = date or datetime.utcnow()
     return date + delta
 
 


### PR DESCRIPTION
Fixes: #158