### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 sudo: false
 
-env:
- - TOXENV=py27
- - TOXENV=py34
+python:
+  - 2.6
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 
-install: "pip install tox"
+install: pip install tox-travis
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34
+envlist = py26, py27, py34, py35, py36
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Add Python 3.5 and 3.6 to tox, and run all tox testenvs in Travis CI.