### PR TITLE
Let's actually use redis right!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cache
+web_cache
 .DS_Store
 *.pyc
 *.pyo

--- a/README.rst
+++ b/README.rst
@@ -38,5 +38,5 @@ result in a simple dictionary.
 For more info, check out the docs_
 
 .. _docs: http://cachecontrol.readthedocs.org/en/latest/
-.. _httplib2: https://github.com/jcgregorio/httplib2
+.. _httplib2: https://github.com/httplib2/httplib2
 .. _requests: http://docs.python-requests.org/

--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -10,7 +10,7 @@ class BaseCache(object):
     def get(self, key):
         raise NotImplemented()
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         raise NotImplemented()
 
     def delete(self, key):
@@ -29,7 +29,7 @@ class DictCache(BaseCache):
     def get(self, key):
         return self.data.get(key, None)
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         with self.lock:
             self.data.update({key: value})
 

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -101,7 +101,7 @@ class FileCache(BaseCache):
         with open(name, 'rb') as fh:
             return fh.read()
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         name = self._fn(key)
 
         # Make sure the directory exists

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -26,8 +26,7 @@ class RedisCache(BaseCache):
         if not expires:
             self.conn.set(key, value)
         else:
-            expires = expires - datetime.utcnow()
-            self.conn.setex(key, total_seconds(expires), value)
+            self.conn.setex(key, value, expires)
 
     def delete(self, key):
         self.conn.delete(key)

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -26,7 +26,7 @@ class RedisCache(BaseCache):
         if not expires:
             self.conn.set(key, value)
         else:
-            self.conn.setex(key, value, expires)
+            self.conn.setex(key, expires, value)
 
     def delete(self, key):
         self.conn.delete(key)

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -26,7 +26,10 @@ class RedisCache(BaseCache):
         if not expires:
             self.conn.set(key, value)
         else:
-            self.conn.setex(key, expires, value)
+            # the keyword arguments are to account for a Redis v StrictRedis issue
+            # with pyredis being a mess. this is compatible with both.
+
+            self.conn.setex(key, expires=expires, value=value)
 
     def delete(self, key):
         self.conn.delete(key)

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -91,7 +91,7 @@ class TestCacheControllerResponse(object):
         req = self.req()
         cc.cache_response(req, resp)
         cc.serializer.dumps.assert_called_with(req, resp, body=None)
-        cc.cache.set.assert_called_with(self.url, ANY)
+        cc.cache.set.assert_called_with(self.url, ANY, expires=3600)
 
     def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):
         now = time.strftime(TIME_FMT, time.gmtime())


### PR DESCRIPTION
This PR fixes the redis cache such that the setex() cache insertion call is actually invoked (it was not previously) and that it sets an appropriate TTL for both the "max-age" and "expires" headers.

Tests are passing for python 2.7 and 3.5. YMMV for others. Then again the build is currently breaking so I can't make that worse!