### PR TITLE
zlib compression of cache objects

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -3,7 +3,7 @@ The cache object API for implementing caches. The default is a thread
 safe in-memory dictionary.
 """
 from threading import Lock
-
+import zlib
 
 class BaseCache(object):
 
@@ -27,11 +27,40 @@ class DictCache(BaseCache):
         self.data = init_dict or {}
 
     def get(self, key):
-        return self.data.get(key, None)
+        value = self.data.get(key, None)
 
-    def set(self, key, value):
-        with self.lock:
+        if value is None:
+            return None
+
+        # to handle testing issues where a Mock object cannot be handled
+        if type(value) is not 'str':
+            return value
+
+        value = zlib.decompress(value.encode('utf-8'))
+
+        return value.decode('utf-8')
+
+    def set(self, key, set_value):
+
+        # mutability damage limiter
+        value = set_value
+
+        if value is None:
+            with self.lock:
+                self.data.update({key: None})
+            return
+
+        # to handle testing issues where a Mock object cannot be handled
+        if type(value) is not 'str':
             self.data.update({key: value})
+            return
+
+        value = value.encode('utf-8')
+        compressed_value = zlib.compress(value, zlib.Z_BEST_COMPRESSION)
+        compressed_value = str(compressed_value)
+
+        with self.lock:
+            self.data.update({key: compressed_value})
 
     def delete(self, key):
         with self.lock:


### PR DESCRIPTION
Does exactly what it says on the tin.

Before I caught onto the madness with redis, my redis requests cache store was 3 gigabytes. Granted it took awhile to do that, but I can't be the only one. Using zlib compression will save a reasonable amount of memory for the memory-based caches cachecontrol can use.

Ought to merge clean with the redis PR. This was written separately. 

Passed tests on my machine. 