### PR TITLE
make CacheControlAdapter picklable

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -31,6 +31,21 @@ class CacheControlAdapter(HTTPAdapter):
             serializer=serializer,
         )
 
+    def __getstate__(self):
+        state = super(CacheControlAdapter, self).__getstate__()
+        state['cache'] = self.cache
+        state['heuristic'] = self.heuristic
+        state['cacheable_methods'] = self.cacheable_methods
+        state['controller'] = self.controller
+        return state
+
+    def __setstate__(self, state):
+        super(CacheControlAdapter, self).__setstate__(state)
+        self.cache = state['cache']
+        self.heuristic = state['heuristic']
+        self.cacheable_methods = state['cacheable_methods']
+        self.controller = state['controller']
+
     def send(self, request, cacheable_methods=None, **kw):
         """
         Send a request. Use the request information to see if it


### PR DESCRIPTION
make CacheControlAdapter picklable,so ready for asyncio->run_in_executor + ProcessPoolExecutor
(1)when I run https://github.com/tastuteche/tell-me-more/blob/master/tell_me_more/github_title.py under python3.5
got error:
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/r/a/p/usr/lib64/python3.5/concurrent/futures/process.py", line 175, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/r/a/p/usr/lib64/python3.5/site-packages/requests/sessions.py", line 515, in get
    return self.request('GET', url, **kwargs)
  File "/r/a/p/usr/lib64/python3.5/site-packages/requests/sessions.py", line 502, in request
    resp = self.send(prep, **send_kwargs)
  File "/r/a/p/usr/lib64/python3.5/site-packages/requests/sessions.py", line 612, in send
    r = adapter.send(request, **kwargs)
  File "/r/a/p/usr/lib64/python3.5/site-packages/cachecontrol/adapter.py", line 39, in send
    cacheable = cacheable_methods or self.cacheable_methods
AttributeError: 'CacheControlAdapter' object has no attribute 'cacheable_methods'
"""
(2)found a fix at stackoverflow
The ProcessPoolExecutor class is an Executor subclass that uses a pool of processes to execute calls asynchronously. ProcessPoolExecutor uses the multiprocessing module, which allows it to side-step the Global Interpreter Lock but also means that only picklable objects can be executed and returned.
https://stackoverflow.com/questions/17419879/why-i-cannot-use-python-module-concurrent-futures-in-class-method