### PR TITLE
Prepended cachecontrol to adapter in usage example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,7 @@ Here is how the adapter works: ::
   import cachecontrol
 
   sess = requests.Session()
-  sess.mount('http://', CacheControlAdapter())
+  sess.mount('http://', cachecontrol.CacheControlAdapter())
 
   resp = sess.get('http://google.com')
 


### PR DESCRIPTION
Since only cachecontrol was imported, it must also be used in the call to CacheControlAdapter()

This is a trivial change but it's also my first pull request ever -- looking forward to contributing in a more substantial way.