### PR TITLE
Fix exception raising in BaseCache

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -8,13 +8,13 @@ from threading import Lock
 class BaseCache(object):
 
     def get(self, key):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def set(self, key, value):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def delete(self, key):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def close(self):
         pass


### PR DESCRIPTION
`NotImplemented` is a sentinel object, not an exception type.
It was mistakenly used instead of `NotImplementedError`.