### PR TITLE
Fix behaviour of Cache-Control: no-store on responses

### DIFF
--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -287,6 +287,8 @@ class CacheController(object):
         if no_store and self.cache.get(cache_url):
             logger.debug('Purging existing cache entry to honor "no-store"')
             self.cache.delete(cache_url)
+        if no_store:
+            return
 
         # If we've been given an etag, then keep the response
         if self.cache_etags and 'etag' in response_headers:

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -115,21 +115,11 @@ class TestCacheControllerResponse(object):
         cc.cache_response(self.req(), resp)
         assert not cc.cache.get(cache_url)
 
-    def test_cache_response_no_store_with_etag(self):
-        resp = Mock()
-        cache = DictCache({self.url: resp})
-        cc = CacheController(cache)
-
-        cache_url = cc.cache_url(self.url)
-
+    def test_cache_response_no_store_with_etag(self, cc):
         resp = self.resp({'cache-control': 'no-store', 'ETag': 'jfd9094r808'})
-        assert cc.cache.get(cache_url)
-
-        # skip serializer as it can't handle mocks
-        cc.serializer = Mock()
-        cc.serializer.loads.return_value = resp
         cc.cache_response(self.req(), resp)
-        assert not cc.cache.get(cache_url)
+
+        assert not cc.cache.set.called
 
     def test_update_cached_response_with_valid_headers(self):
         cached_resp = Mock(headers={'ETag': 'jfd9094r808', 'Content-Length': 100})

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -115,6 +115,22 @@ class TestCacheControllerResponse(object):
         cc.cache_response(self.req(), resp)
         assert not cc.cache.get(cache_url)
 
+    def test_cache_response_no_store_with_etag(self):
+        resp = Mock()
+        cache = DictCache({self.url: resp})
+        cc = CacheController(cache)
+
+        cache_url = cc.cache_url(self.url)
+
+        resp = self.resp({'cache-control': 'no-store', 'ETag': 'jfd9094r808'})
+        assert cc.cache.get(cache_url)
+
+        # skip serializer as it can't handle mocks
+        cc.serializer = Mock()
+        cc.serializer.loads.return_value = resp
+        cc.cache_response(self.req(), resp)
+        assert not cc.cache.get(cache_url)
+
     def test_update_cached_response_with_valid_headers(self):
         cached_resp = Mock(headers={'ETag': 'jfd9094r808', 'Content-Length': 100})
 


### PR DESCRIPTION
According to RFC 7234, section 5.2.2.3: Response Cache-Control
Directives, no-store:

> The "no-store" response directive indicates that a cache MUST NOT
> store any part of either the immediate request or response.  This
> directive applies to both private and shared caches.  "MUST NOT
> store" in this context means that the cache MUST NOT intentionally
> store the information in non-volatile storage, and MUST make a
> best-effort attempt to remove the information from volatile storage
> as promptly as possible after forwarding it.[...]

https://tools.ietf.org/html/rfc7234#section-5.2.2.3

The second part ("[...] MUST make a best-effort attempt to
remove the information [...]") was already handled, but if any other
conditions for caching responses became true, for example presence of
Etags, permanent redirect etc. the response was cached even with
``Cache-Control: no-store``.

This behaviour is fixed by just returning from ``cache_response`` if the ``no_store`` flag is set,
potentially after having purged the cache entry.