### PR TITLE
Test if cache is None before falling back to DictCache

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -24,7 +24,7 @@ class CacheControlAdapter(HTTPAdapter):
         **kw
     ):
         super(CacheControlAdapter, self).__init__(*args, **kw)
-        self.cache = cache or DictCache()
+        self.cache = DictCache() if cache is None else cache
         self.heuristic = heuristic
         self.cacheable_methods = cacheable_methods or ("GET",)
 

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -34,7 +34,7 @@ class CacheController(object):
     def __init__(
         self, cache=None, cache_etags=True, serializer=None, status_codes=None
     ):
-        self.cache = cache or DictCache()
+        self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
         self.cacheable_status_codes = status_codes or (200, 203, 300, 301)

--- a/cachecontrol/wrapper.py
+++ b/cachecontrol/wrapper.py
@@ -13,7 +13,7 @@ def CacheControl(
     cacheable_methods=None,
 ):
 
-    cache = cache or DictCache()
+    cache = DictCache() if cache is None else cache
     adapter_class = adapter_class or CacheControlAdapter
     adapter = adapter_class(
         cache,


### PR DESCRIPTION
This allows passing in a cache instance that is falsy.

The reason for this change is that python-diskcache's cache backends implement a `__len__` method which returns the number of cache entries. If this is zero cachecontrol will fall back to `DictCache`.

I've also created a PR for python-diskcache to correct this somewhat unexpected behavior. (https://github.com/grantjenks/python-diskcache/pull/77)