### PR TITLE
Make v4 cache compatible with msgpack 1.0 in the future

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -181,7 +181,7 @@ class Serializer(object):
 
     def _loads_v4(self, request, data):
         try:
-            cached = msgpack.loads(data, encoding="utf-8")
+            cached = msgpack.loads(data, raw=False)
         except ValueError:
             return
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_params = dict(
     include_package_data=True,
     description="httplib2 caching for requests",
     long_description=long_description,
-    install_requires=["requests", "msgpack"],
+    install_requires=["requests", "msgpack>=0.5.2"],
     extras_require={"filecache": ["lockfile>=0.9"], "redis": ["redis>=2.10.5"]},
     entry_points={"console_scripts": ["doesitcache = cachecontrol._cmd:main"]},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",


### PR DESCRIPTION
The `encoding` parameter in `msgpack.loads` is deprecated and will be
removed in msgpack 1.0 [1].

Note that the `raw` parameter was called `raw_as_bytes` before 0.5.2
[2]. I add the version constraint to avoid API incompatibilities.

[1] https://github.com/msgpack/msgpack-python/issues/191
[2] https://github.com/msgpack/msgpack-python/commit/5569a4efcdc913d343eaff4e55c9b19fafde4268