### PR TITLE
Fixed test setup for pytest >= 4.1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ class SimpleApp(object):
 
 @pytest.fixture(scope="session")
 def server():
-    return pytest.server
+    return cherrypy.server
 
 
 @pytest.fixture()
@@ -124,7 +124,7 @@ def get_free_port():
     return ip, port
 
 
-def pytest_namespace():
+def pytest_configure(config):
     cherrypy.tree.graft(SimpleApp(), "/")
 
     ip, port = get_free_port()
@@ -136,7 +136,6 @@ def pytest_namespace():
     logger.removeHandler(logger.handlers[0])
 
     cherrypy.server.start()
-    return {"server": cherrypy.server}
 
 
 def pytest_unconfigure(config):


### PR DESCRIPTION
The `pytest_namespace` hook was removed in pytest 4.0 according to [their website](https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace), but appears to work fine until version 4.1. Using that version yields a `pluggy.manager.PluginValidationError: unknown hook 'pytest_namespace'`.
This hook is used in `tests/conftest.py` to add `cherrypy.server` to the `pytest` namespace. Since the server instance is available through the `cherrypy` module globally anyway, I replaced the only reference to it (in the server fixture in the same file) by a reference to `cherrypy.server` and swapped `pytest_namespace` for `pytest_configure` for the initial setup of the server. This allows the tests to run as usual.