### PR TITLE
Added support for expiry on the Redis backend.

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -10,7 +10,7 @@ class BaseCache(object):
     def get(self, key):
         raise NotImplementedError()
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         raise NotImplementedError()
 
     def delete(self, key):
@@ -29,7 +29,7 @@ class DictCache(BaseCache):
     def get(self, key):
         return self.data.get(key, None)
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         with self.lock:
             self.data.update({key: value})
 

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -114,7 +114,8 @@ class FileCache(BaseCache):
         except FileNotFoundError:
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
+        # NOTE: `expires` is not used by this cache backend.
         name = self._fn(key)
 
         # Make sure the directory exists

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -13,7 +13,7 @@ class RedisCache(BaseCache):
         return self.conn.get(key)
 
     def set(self, key, value, expires=None):
-        self.conn.set(key, value, ex=expires)
+        self.conn.set(key, value, ex=expires or None)
 
     def delete(self, key):
         self.conn.delete(key)

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -13,11 +13,7 @@ class RedisCache(BaseCache):
         return self.conn.get(key)
 
     def set(self, key, value, expires=None):
-        if not expires:
-            self.conn.set(key, value)
-        else:
-            expires = expires - datetime.utcnow()
-            self.conn.setex(key, int(expires.total_seconds()), value)
+        self.conn.set(key, value, ex=expires)
 
     def delete(self, key):
         self.conn.delete(key)

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -83,7 +83,7 @@ class TestCacheControllerResponse(object):
         req = self.req()
         cc.cache_response(req, resp)
         cc.serializer.dumps.assert_called_with(req, resp, body=None)
-        cc.cache.set.assert_called_with(self.url, ANY)
+        cc.cache.set.assert_called_with(self.url, ANY, expires=3600)
 
     def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):
         now = time.strftime(TIME_FMT, time.gmtime())

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -13,3 +13,11 @@ class TestRedisCache(object):
     def test_set_expiration(self):
         self.cache.set("foo", "bar", expires=3600)
         self.conn.set.assert_called_with("foo", "bar", ex=3600)
+
+    def test_set_invalid_age(self):
+        """
+        Verify that expires=0 will not cause Redis to throw an error.   It must be passed
+        as None or we receive: ResponseError: invalid expire time in set)
+        """
+        self.cache.set("foo", "bar", expires=0)
+        self.conn.set.assert_called_with("foo", "bar", ex=None)

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -11,5 +11,5 @@ class TestRedisCache(object):
         self.cache = RedisCache(self.conn)
 
     def test_set_expiration(self):
-        self.cache.set("foo", "bar", expires=datetime(2014, 2, 2))
-        assert self.conn.setex.called
+        self.cache.set("foo", "bar", expires=3600)
+        self.conn.set.assert_called_with("foo", "bar", ex=3600)


### PR DESCRIPTION
The CacheController does not pass an expiry key to supported backends, aka. Redis. This commit adds support for deriving a TTL from the response headers and passing that to the cache backend allowing the cache to expire old caches automatically.

When using this library in an environment with lots of traffic and rapidly expiring caches we noticed that the Redis backend never received an expiry argument.  We added this before noticing an existing pull request for the same functionality.  That pull request appears to be fairly old and no longer merges so I've updated our changes to incorporate some of the notes on the old one.

Some notes:
 - I changed the argument to RedisCache.set() from a date to an int and put the logic for determining the expiry time in CacheController.get_cache_expiry()
 - I changed the Redis method from setex(name, expiry, value) to set(name, value, ex=expiry) to avoid the whole argument order affair.
 - I added CacheController.CACHE_TTL_MAX to avoid storing keys forever in Redis and allow users to enforce a maximum cache duration (defaults to 2 weeks).  This is potentially outside the scope of this feature, if it creates problems let's drop it.

