### PR TITLE
Fix httplib2 links.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,5 +38,5 @@ result in a simple dictionary.
 For more info, check out the docs_
 
 .. _docs: http://cachecontrol.readthedocs.org/en/latest/
-.. _httplib2: https://github.com/jcgregorio/httplib2
+.. _httplib2: https://github.com/httplib2/httplib2
 .. _requests: http://docs.python-requests.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ production environments, replacing httplib2's usage.
 If you give it a try, please let me know of any issues.
 
 
-.. _httplib2: http://code.google.com/p/httplib2/
+.. _httplib2: https://github.com/httplib2/httplib2
 .. _requests: http://docs.python-requests.org/
 .. _Editing the Web: http://www.w3.org/1999/04/Editing/
 .. _PyPI: https://pypi.python.org/pypi/CacheControl/

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -104,7 +104,7 @@ Third-Party Cache Providers
 
 
 
-.. _httplib2: http://code.google.com/p/httplib2/
+.. _httplib2: https://github.com/httplib2/httplib2
 .. _lockfile: https://github.com/smontanaro/pylockfile
 .. _requests 2.1: http://docs.python-requests.org/en/latest/community/updates/#id2
 .. _redis: https://github.com/andymccurdy/redis-py


### PR DESCRIPTION
httplib2 development moved to https://github.com/httplib2/httplib2.