### PR TITLE
Publish sdist and bdist wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ coverage:
 	$(VENV)/bin/py.test --cov cachecontrol
 
 release: dist
-	$(VENV)/bin/twine upload dist/CacheControl-*.tar.gz
+	$(VENV)/bin/twine upload dist/*
 
 dist: clean
-	python setup.py sdist
+	python setup.py sdist bdist_wheel
 	ls -l dist
 
 bump:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,3 +11,4 @@ lockfile
 bumpversion
 twine
 black
+wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [tool:pytest]
 norecursedirs = bin lib include build
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The benefits of wheels are well documented. See: https://pythonwheels.com/

This package is pure Python and publishing it as both source and as a wheel is simple. 