### PR TITLE
add patch as invalidating http method

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -10,7 +10,7 @@ from .filewrapper import CallbackFileWrapper
 
 
 class CacheControlAdapter(HTTPAdapter):
-    invalidating_methods = {"PUT", "DELETE"}
+    invalidating_methods = {"PUT", "PATCH", "DELETE"}
 
     def __init__(
         self,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -45,6 +45,11 @@ class TestSessionActions(object):
         sess.get(url)
         assert not r2.from_cache
 
+    def test_patch_invalidates_cache(self, url, sess):
+        r2 = sess.patch(url, data={"foo": "bar"})
+        sess.get(url)
+        assert not r2.from_cache
+
     def test_delete_invalidates_cache(self, url, sess):
         r2 = sess.delete(url)
         sess.get(url)


### PR DESCRIPTION
Patch mutates a resource and therefore should invalidate the cache to ensure clients get fresh content.