### PR TITLE
Properly support modern 308 Permanent Redirect responses.

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -4,7 +4,7 @@ import zlib
 
 from requests.adapters import HTTPAdapter
 
-from .controller import CacheController
+from .controller import CacheController, PERMANENT_REDIRECT_STATUSES
 from .cache import DictCache
 from .filewrapper import CallbackFileWrapper
 
@@ -93,7 +93,7 @@ class CacheControlAdapter(HTTPAdapter):
                 response = cached_response
 
             # We always cache the 301 responses
-            elif response.status == 301:
+            elif int(response.status) in PERMANENT_REDIRECT_STATUSES:
                 self.controller.cache_response(request, response)
             else:
                 # Wrap the response file with a wrapper that will cache the

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -312,7 +312,7 @@ class CacheController(object):
         # Add to the cache any 301s. We do this before looking that
         # the Date headers.
         elif response.status == 301:
-            logger.debug("Caching permanant redirect")
+            logger.debug("Caching permanent redirect")
             self.cache.set(cache_url, self.serializer.dumps(request, response))
 
         # Add to the cache if the response headers demand it. If there

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")
 
+PERMANENT_REDIRECT_STATUSES = (301, 308)
+
 
 def parse_uri(uri):
     """Parses a URI using the regex given in Appendix B of RFC 3986.
@@ -37,7 +39,7 @@ class CacheController(object):
         self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
-        self.cacheable_status_codes = status_codes or (200, 203, 300, 301)
+        self.cacheable_status_codes = status_codes or (200, 203, 300, 301, 308)
 
     @classmethod
     def _urlnorm(cls, uri):
@@ -147,17 +149,18 @@ class CacheController(object):
             logger.warning("Cache entry deserialization failed, entry ignored")
             return False
 
-        # If we have a cached 301, return it immediately. We don't
-        # need to test our response for other headers b/c it is
+        # If we have a cached permanent redirect, return it immediately. We
+        # don't need to test our response for other headers b/c it is
         # intrinsically "cacheable" as it is Permanent.
+        #
         # See:
         #   https://tools.ietf.org/html/rfc7231#section-6.4.2
         #
         # Client can try to refresh the value by repeating the request
         # with cache busting headers as usual (ie no-cache).
-        if resp.status == 301:
+        if int(resp.status) in PERMANENT_REDIRECT_STATUSES:
             msg = (
-                'Returning cached "301 Moved Permanently" response '
+                'Returning cached permanent redirect response '
                 "(ignoring date and etag information)"
             )
             logger.debug(msg)
@@ -309,9 +312,9 @@ class CacheController(object):
                 cache_url, self.serializer.dumps(request, response, body=body)
             )
 
-        # Add to the cache any 301s. We do this before looking that
-        # the Date headers.
-        elif response.status == 301:
+        # Add to the cache any permanent redirects. We do this before looking
+        # that the Date headers.
+        elif int(response.status) in PERMANENT_REDIRECT_STATUSES:
             logger.debug("Caching permanent redirect")
             self.cache.set(cache_url, self.serializer.dumps(request, response))
 

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -17,25 +17,13 @@ def _b64_decode_str(s):
     return _b64_decode_bytes(s).decode("utf8")
 
 
+_default_body_read = object()
+
+
 class Serializer(object):
 
-    def dumps(self, request, response, body=None):
+    def dumps(self, request, response, body):
         response_headers = CaseInsensitiveDict(response.headers)
-
-        if body is None:
-            body = response.read(decode_content=False)
-
-            # NOTE: 99% sure this is dead code. I'm only leaving it
-            #       here b/c I don't have a test yet to prove
-            #       it. Basically, before using
-            #       `cachecontrol.filewrapper.CallbackFileWrapper`,
-            #       this made an effort to reset the file handle. The
-            #       `CallbackFileWrapper` short circuits this code by
-            #       setting the body as the content is consumed, the
-            #       result being a `body` argument is *always* passed
-            #       into cache_response, and in turn,
-            #       `Serializer.dump`.
-            response._fp = io.BytesIO(body)
 
         # NOTE: This is all a bit weird, but it's really important that on
         #       Python 2.x these objects are unicode and not str, even when

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -152,7 +152,7 @@ class TestCacheControlRequest(object):
         return self.c.cached_request(mock_request)
 
     def test_cache_request_no_headers(self):
-        cached_resp = Mock(headers={"ETag": "jfd9094r808", "Content-Length": 100})
+        cached_resp = Mock(headers={"ETag": "jfd9094r808", "Content-Length": 100}, status=200)
         self.c.cache = DictCache({self.url: cached_resp})
         resp = self.req({})
         assert not resp
@@ -179,7 +179,7 @@ class TestCacheControlRequest(object):
 
     def test_cache_request_fresh_max_age(self):
         now = time.strftime(TIME_FMT, time.gmtime())
-        resp = Mock(headers={"cache-control": "max-age=3600", "date": now})
+        resp = Mock(headers={"cache-control": "max-age=3600", "date": now}, status=200)
 
         cache = DictCache({self.url: resp})
         self.c.cache = cache
@@ -189,7 +189,7 @@ class TestCacheControlRequest(object):
     def test_cache_request_unfresh_max_age(self):
         earlier = time.time() - 3700  # epoch - 1h01m40s
         now = time.strftime(TIME_FMT, time.gmtime(earlier))
-        resp = Mock(headers={"cache-control": "max-age=3600", "date": now})
+        resp = Mock(headers={"cache-control": "max-age=3600", "date": now}, status=200)
         self.c.cache = DictCache({self.url: resp})
         r = self.req({})
         assert not r
@@ -198,7 +198,7 @@ class TestCacheControlRequest(object):
         later = time.time() + 86400  # GMT + 1 day
         expires = time.strftime(TIME_FMT, time.gmtime(later))
         now = time.strftime(TIME_FMT, time.gmtime())
-        resp = Mock(headers={"expires": expires, "date": now})
+        resp = Mock(headers={"expires": expires, "date": now}, status=200)
         cache = DictCache({self.url: resp})
         self.c.cache = cache
         r = self.req({})
@@ -208,7 +208,7 @@ class TestCacheControlRequest(object):
         sooner = time.time() - 86400  # GMT - 1 day
         expires = time.strftime(TIME_FMT, time.gmtime(sooner))
         now = time.strftime(TIME_FMT, time.gmtime())
-        resp = Mock(headers={"expires": expires, "date": now})
+        resp = Mock(headers={"expires": expires, "date": now}, status=200)
         cache = DictCache({self.url: resp})
         self.c.cache = cache
         r = self.req({})
@@ -217,7 +217,7 @@ class TestCacheControlRequest(object):
     def test_cached_request_with_bad_max_age_headers_not_returned(self):
         now = time.strftime(TIME_FMT, time.gmtime())
         # Not a valid header; this would be from a misconfigured server
-        resp = Mock(headers={"cache-control": "max-age=xxx", "date": now})
+        resp = Mock(headers={"cache-control": "max-age=xxx", "date": now}, status=200)
 
         self.c.cache = DictCache({self.url: resp})
 

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -67,7 +67,7 @@ class TestCacheControllerResponse(object):
         # When the body is the wrong size, then we don't want to cache it
         # because it is obviously broken.
         resp = self.resp({"cache-control": "max-age=3600", "Content-Length": "5"})
-        cc.cache_response(self.req(), resp, body=b"0" * 10)
+        cc.cache_response(self.req(), resp, b"0" * 10)
 
         assert not cc.cache.set.called
 
@@ -82,7 +82,7 @@ class TestCacheControllerResponse(object):
         resp = self.resp({"cache-control": "max-age=3600", "date": now})
         req = self.req()
         cc.cache_response(req, resp)
-        cc.serializer.dumps.assert_called_with(req, resp, body=None)
+        cc.serializer.dumps.assert_called_with(req, resp, None)
         cc.cache.set.assert_called_with(self.url, ANY)
 
     def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -89,7 +89,7 @@ class TestSerializer(object):
         original_resp = requests.get(url, stream=True)
         req = original_resp.request
 
-        resp = self.serializer.loads(req, self.serializer.dumps(req, original_resp.raw))
+        resp = self.serializer.loads(req, self.serializer.dumps(req, original_resp.raw, original_resp.content))
 
         assert resp.read()
 
@@ -99,7 +99,7 @@ class TestSerializer(object):
         req = original_resp.request
 
         resp = self.serializer.loads(
-            req, self.serializer.dumps(req, original_resp.raw, body=data)
+            req, self.serializer.dumps(req, original_resp.raw, data)
         )
 
         assert resp.read() == data
@@ -114,5 +114,5 @@ class TestSerializer(object):
         original_resp.raw.headers["vary"] = "Foo"
 
         assert self.serializer.loads(
-            req, self.serializer.dumps(req, original_resp.raw, body=data)
+            req, self.serializer.dumps(req, original_resp.raw, data)
         )


### PR DESCRIPTION
This includes a few separate changes that are needed to make caching 308 Permanent Redirect responses effective.