### PR TITLE
add expires parameter to base class

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -14,7 +14,7 @@ class BaseCache(object):
     def get(self, key):
         raise NotImplementedError()
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         raise NotImplementedError()
 
     def delete(self, key):
@@ -33,7 +33,7 @@ class DictCache(BaseCache):
     def get(self, key):
         return self.data.get(key, None)
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         with self.lock:
             self.data.update({key: value})
 

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -118,7 +118,7 @@ class FileCache(BaseCache):
         except FileNotFoundError:
             return None
 
-    def set(self, key, value):
+    def set(self, key, value, expires=None):
         name = self._fn(key)
 
         # Make sure the directory exists

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -87,7 +87,7 @@ class TestCacheControllerResponse(object):
         req = self.req()
         cc.cache_response(req, resp)
         cc.serializer.dumps.assert_called_with(req, resp, None)
-        cc.cache.set.assert_called_with(self.url, ANY)
+        cc.cache.set.assert_called_with(self.url, ANY, expires=3600)
 
     def test_cache_response_cache_max_age_with_invalid_value_not_cached(self, cc):
         now = time.strftime(TIME_FMT, time.gmtime())


### PR DESCRIPTION
This PR is based on https://github.com/ionrock/cachecontrol/pull/168 but I have removed all the Redis related code as it is not needed for my use case. 

I have some other cache types based on BaseCache and would like to be able to pass through an expires parameter so that I can set a custom TTL in our backend cache.
