### PR TITLE
Cache from status code 302

### DIFF
--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -96,7 +96,7 @@ class CacheControlAdapter(HTTPAdapter):
 
                 response = cached_response
 
-            # We always cache the 301 responses
+            # We always cache the 301, 302 and 308 responses
             elif int(response.status) in PERMANENT_REDIRECT_STATUSES:
                 self.controller.cache_response(request, response)
             else:

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 URI = re.compile(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?")
 
-PERMANENT_REDIRECT_STATUSES = (301, 308)
+PERMANENT_REDIRECT_STATUSES = (301, 302, 308)
 
 
 def parse_uri(uri):
@@ -43,7 +43,7 @@ class CacheController(object):
         self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
-        self.cacheable_status_codes = status_codes or (200, 203, 300, 301, 308)
+        self.cacheable_status_codes = status_codes or (200, 203, 300, 301, 302, 308)
 
     @classmethod
     def _urlnorm(cls, uri):


### PR DESCRIPTION
On issue https://github.com/pypa/pip/issues/8643 log we can see
that github response with a 302 status code [0]. From my point
of view status code 302 is similary to 301 that already is
accepted by cachecontrol, so shouldn't represent a problem
support 302 status code to cache.

[0] https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302