### PR TITLE
Fix a broken test

### DIFF
--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -137,7 +137,7 @@ class TestCacheControllerResponse(object):
         # skip our in/out processing
         cc.serializer = Mock()
         cc.serializer.loads.return_value = cached_resp
-        cc.cache_url = Mock(return_value="http://foo.com")
+        cc.cache_url = Mock(return_value=self.url)
 
         result = cc.update_cached_response(Mock(), resp)
 


### PR DESCRIPTION
`test_update_cached_response_with_valid_headers` is wrong even though
it currently passes. As far as I can tell it attempts to emulate the
following scenario:
* There is already a cached response for `http://url.com/`
* `CacheController.update_cached_response` is called with a request and
a validation response for the same url

The problem is: it incorrectly sets the second url to `http://foo.com`.
This causes `CacheController.cache.get(cache_url)` to return None.
The test currently passes because `CacheController.serializer.loads`
is mocked and `CacheController.update_cached_response` currently passes
`CacheController.cache.get(cache_url)` to `CacheController.serializer.loads` unconditionally:
https://github.com/ionrock/cachecontrol/blob/f51196020d8f6ec0d696f3baffa66fa0053ff1c9/cachecontrol/controller.py#L386

This test failed when I tried to refactor the code