### PR TITLE
Stand-alone test_file_cache_recognizes_consumed_file_handle()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,11 @@ class SimpleApp(object):
             start_response("200 OK", headers)
         return [pformat(env).encode("utf8")]
 
+    def cache_60(self, env, start_response):
+        headers = [("Cache-Control", "public, max-age=60")]
+        start_response("200 OK", headers)
+        return [pformat(env).encode("utf8")]
+
     def no_cache(self, env, start_response):
         headers = [("Cache-Control", "no-cache")]
         start_response("200 OK", headers)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -17,10 +17,11 @@ class Test39(object):
     @pytest.mark.skipif(
         sys.version.startswith("2"), reason="Only run this for python 3.x"
     )
-    def test_file_cache_recognizes_consumed_file_handle(self):
+    def test_file_cache_recognizes_consumed_file_handle(self, url):
         s = CacheControl(Session(), FileCache("web_cache"))
-        s.get("http://httpbin.org/cache/60")
-        r = s.get("http://httpbin.org/cache/60")
+        the_url = url + "cache_60"
+        s.get(the_url)
+        r = s.get(the_url)
         assert r.from_cache
         s.close()
 


### PR DESCRIPTION
Avoid using httpbin.org for an endpoint that we can serve ourselves.

This helps Debian to run the test suite for cachecontrol in our test infrastructure, without Internet access.