### PR TITLE
Rebased elnuno's fix and retested: "Close CallbackFileWrapper.__buf once it's used."

### DIFF
--- a/cachecontrol/filewrapper.py
+++ b/cachecontrol/filewrapper.py
@@ -62,9 +62,16 @@ class CallbackFileWrapper(object):
         # and allows the garbage collector to do it's thing normally.
         self.__callback = None
 
+        # Closing the BytesIO stream releases memory. Important when caching
+        # big files.
+        self.__buf.close()
+
     def read(self, amt=None):
         data = self.__fp.read(amt)
-        self.__buf.write(data)
+        if data:
+            # We may be dealing with b'', a sign that things are over:
+            # it's passed e.g. after we've already closed self.__buf.
+            self.__buf.write(data)
         if self.__is_fp_closed():
             self._close()
 


### PR DESCRIPTION
I noticed it hadn't been updated in a while so I just pulled it down and rebased it on the latest master, and re-tested it using the script @elnuno used (and `pytest`).

With @elnuno 's change (and a ~70mb file):
```
Using 36 MB on program end.
Mean memory use: 26 MB
```

Without:
```
Using 77 MB on program end.
Mean memory use: 189 MB
``` 

This is exactly the same changes as in:
https://github.com/ionrock/cachecontrol/pull/152

Just rebased as @ionrock had requested in 2018 with the hope of it getting merged. 

EDIT: Obviously I don't deserve any credit for this, just trying to help get @elnuno 's fix in.