### PR TITLE
Work in progress, opened for initial API review: streaming APIs

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -43,7 +43,7 @@ class CacheInterface(ABC):
     can support both.
     """
 
-    def get_as_file(self, key: str, serializer: Serializer) -> HTTPResponse:
+    def get_as_file(self, key: str, request, serializer: Serializer) -> HTTPResponse:
         """
         Return tuple of (encoded-metadata file-like, body file-like).
         """

--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -7,9 +7,13 @@ The cache object API for implementing caches. The default is a thread
 safe in-memory dictionary.
 """
 from threading import Lock
+from typing import Tuple, BinaryIO, Optional
+from pathlib import Path
+from abc import ABC
 
 
-class BaseCache(object):
+class LegacyCache(object):
+    """Legacy cache interface."""
 
     def get(self, key):
         raise NotImplementedError()
@@ -24,8 +28,49 @@ class BaseCache(object):
         pass
 
 
-class DictCache(BaseCache):
+BaseCache = LegacyCache  # backwards compatibility
 
+
+class CacheInterface(ABC):
+    """New interface for caches.
+
+    The metadata is stored separately from the body data, in order to make it
+    easy to directly stream large amounts of data to disk.
+
+    This is deliberately compatible with the old interface, so implementations
+    can support both.
+    """
+
+    def get_as_file(self, key: str) -> Tuple[bytes, BinaryIO]:
+        """
+        Return tuple of (encoded-metadata, readable file-like object for body).
+        """
+
+    def set_from_file(
+        self,
+        key: str,
+        metadata_value: bytes,
+        body_path: Path,
+        expires: Optional[int] = None,
+    ):
+        """
+        Store a cache entry, with metadata and body being passed in separately,
+        the latter as a path to a file.  The metadata is encoded.  Expiration
+        time is a duration (from the present moment) in seconds.
+        """
+
+    def delete(self, key: str):
+        """
+        Delete an entry.
+        """
+
+    def close(self):
+        """
+        Close the cache.
+        """
+
+
+class DictCache(BaseCache):
     def __init__(self, init_dict=None):
         self.lock = Lock()
         self.data = init_dict or {}

--- a/cachecontrol/caches/file_cache.py
+++ b/cachecontrol/caches/file_cache.py
@@ -5,15 +5,13 @@
 import hashlib
 import os
 from textwrap import dedent
+from pathlib import Path
+from typing import Optional, Tuple
 
-from ..cache import BaseCache
+from ..cache import BaseCache, CacheInterface
 from ..controller import CacheController
-
-try:
-    FileNotFoundError
-except NameError:
-    # py2.X
-    FileNotFoundError = (IOError, OSError)
+from ..serialize import Serializer
+from ..compat import HTTPResponse
 
 
 def _secure_open_write(filename, fmode):
@@ -57,8 +55,37 @@ def _secure_open_write(filename, fmode):
         raise
 
 
-class FileCache(BaseCache):
+def _get_dir_lock_class(use_dir_lock, lock_class):
+    if use_dir_lock is not None and lock_class is not None:
+        raise ValueError("Cannot use use_dir_lock and lock_class together")
 
+    try:
+        from lockfile import LockFile
+        from lockfile.mkdirlockfile import MkdirLockFile
+    except ImportError:
+        notice = dedent(
+            """
+        NOTE: In order to use the FileCache you must have
+        lockfile installed. You can install it via pip:
+          pip install lockfile
+        """
+        )
+        raise ImportError(notice)
+
+    else:
+        if use_dir_lock:
+            lock_class = MkdirLockFile
+
+        elif lock_class is None:
+            lock_class = LockFile
+    return lock_class
+
+
+class FileCache(BaseCache):
+    """
+    A legacy cache for backwards compatibility.  You should use
+    ``StreamingFileCache`` instead in new code.
+    """
     def __init__(
         self,
         directory,
@@ -68,30 +95,7 @@ class FileCache(BaseCache):
         use_dir_lock=None,
         lock_class=None,
     ):
-
-        if use_dir_lock is not None and lock_class is not None:
-            raise ValueError("Cannot use use_dir_lock and lock_class together")
-
-        try:
-            from lockfile import LockFile
-            from lockfile.mkdirlockfile import MkdirLockFile
-        except ImportError:
-            notice = dedent(
-                """
-            NOTE: In order to use the FileCache you must have
-            lockfile installed. You can install it via pip:
-              pip install lockfile
-            """
-            )
-            raise ImportError(notice)
-
-        else:
-            if use_dir_lock:
-                lock_class = MkdirLockFile
-
-            elif lock_class is None:
-                lock_class = LockFile
-
+        lock_class = _get_dir_lock_class(use_dir_lock, lock_class)
         self.directory = directory
         self.forever = forever
         self.filemode = filemode
@@ -141,10 +145,91 @@ class FileCache(BaseCache):
                 pass
 
 
-def url_to_file_path(url, filecache):
+def url_to_file_path(url, filecache: FileCache):
     """Return the file cache path based on the URL.
 
     This does not ensure the file exists!
     """
+    assert isinstance(filecache, FileCache)
     key = CacheController.cache_url(url)
     return filecache._fn(key)
+
+
+class StreamingFileCache(CacheInterface):
+    """
+    A file-based cache that uses significantly less memory than ``FileCache``.
+    """
+    def __init__(
+        self,
+        directory,
+        forever=False,
+        filemode=0o0600,
+        dirmode=0o0700,
+        use_dir_lock=None,
+        lock_class=None,
+    ):
+        lock_class = _get_dir_lock_class(use_dir_lock, lock_class)
+        self._directory = Path(directory)
+        self._forever = forever
+        self._filemode = filemode
+        self._dirmode = dirmode
+        self._lock_class = lock_class
+
+    def _filenames(self, name: str) -> Tuple[Path, Path]:
+        """Returns (metadata path, body path)."""
+        hashed = hashlib.sha224(name.encode("utf-8")).hexdigest()
+        parts = list(hashed[:5]) + [hashed]
+        base_path = self._directory / Path(*parts)
+        return base_path.with_suffix(".metadata"), base_path.with_suffix(".body")
+
+    def get_as_file(self, key: str, request, serializer: Serializer) -> HTTPResponse:
+        """
+        Return tuple of (encoded-metadata file-like, body file-like).
+        """
+        metadata_path, body_path = self._filenames(key)
+        return serializer.loads_separate(request, metadata_path.read_bytes(), body_path.open("rb"))
+
+    def set_from_file(
+        self,
+        key: str,
+        metadata_value: bytes,
+        body_path: Path,
+        expires: Optional[int] = None,
+    ):
+        """
+        Store a cache entry, with metadata and body being passed in separately,
+        the latter as a path to a file.  The metadata is encoded.  Expiration
+        time is a duration (from the present moment) in seconds.
+        """
+        metadata_path, new_body_path = self._filenames(key)
+
+        # Make sure the directories exist:
+        metadata_path.parent.mkdir(self._dirmode, parents=True, exists_ok=True)
+
+        with self._lock_class(str(metadata_path)):
+            with self._lock_class(str(body_path)):
+                with _secure_open_write(metadata_path.path, self._filemode) as f:
+                    f.write(metadata_value)
+                body_path.rename(new_body_path)
+                body_path.chmod(self._filemode)
+
+    def delete(self, key: str):
+        """
+        Delete an entry.
+        """
+        if not self._forever:
+            metadata_path, new_body_path = self._filenames(key)
+            try:
+                metadata_path.remove()
+            except FileNotFoundError:
+                pass
+            try:
+                new_body_path.remove()
+            except FileNotFoundError:
+                pass
+
+    def close(self):
+        """
+        Close the cache.
+        """
+        pass

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -27,15 +27,14 @@ PERMANENT_REDIRECT_STATUSES = (301, 308)
 def parse_uri(uri):
     """Parses a URI using the regex given in Appendix B of RFC 3986.
 
-        (scheme, authority, path, query, fragment) = parse_uri(uri)
+    (scheme, authority, path, query, fragment) = parse_uri(uri)
     """
     groups = URI.match(uri).groups()
     return (groups[1], groups[3], groups[4], groups[6], groups[8])
 
 
 class CacheController(object):
-    """An interface to see if request should cached or not.
-    """
+    """An interface to see if request should cached or not."""
 
     def __init__(
         self, cache=None, cache_etags=True, serializer=None, status_codes=None
@@ -251,6 +250,16 @@ class CacheController(object):
 
         return new_headers
 
+    def _cache_set(self, cache_url, request, response, body=None, expires_time=None):
+        """
+        Store the data in the cache.
+        """
+        self.cache.set(
+            cache_url,
+            self.serializer.dumps(request, response, body),
+            expires=expires_time,
+        )
+
     def cache_response(self, request, response, body=None, status_codes=None):
         """
         Algorithm for caching requests.
@@ -326,17 +335,13 @@ class CacheController(object):
 
             logger.debug("etag object cached for {0} seconds".format(expires_time))
             logger.debug("Caching due to etag")
-            self.cache.set(
-                cache_url,
-                self.serializer.dumps(request, response, body),
-                expires=expires_time,
-            )
+            self._cache_set(cache_url, request, response, body, expires_time)
 
         # Add to the cache any permanent redirects. We do this before looking
         # that the Date headers.
         elif int(response.status) in PERMANENT_REDIRECT_STATUSES:
             logger.debug("Caching permanent redirect")
-            self.cache.set(cache_url, self.serializer.dumps(request, response, b""))
+            self._cache_set(cache_url, request, response, b"")
 
         # Add to the cache if the response headers demand it. If there
         # is no date header then we can't do anything about expiring
@@ -347,10 +352,12 @@ class CacheController(object):
             if "max-age" in cc and cc["max-age"] > 0:
                 logger.debug("Caching b/c date exists and max-age > 0")
                 expires_time = cc["max-age"]
-                self.cache.set(
+                self._cache_set(
                     cache_url,
-                    self.serializer.dumps(request, response, body),
-                    expires=expires_time,
+                    request,
+                    response,
+                    body,
+                    expires_time,
                 )
 
             # If the request can expire, it means we should cache it
@@ -368,10 +375,12 @@ class CacheController(object):
                             expires_time
                         )
                     )
-                    self.cache.set(
+                    self._cache_set(
                         cache_url,
-                        self.serializer.dumps(request, response, body=body),
-                        expires=expires_time,
+                        request,
+                        response,
+                        body,
+                        expires_time,
                     )
 
     def update_cached_response(self, request, response):
@@ -410,6 +419,6 @@ class CacheController(object):
         cached_response.status = 200
 
         # update our cache
-        self.cache.set(cache_url, self.serializer.dumps(request, cached_response))
+        self._cache_set(cache_url, request, cached_response)
 
         return cached_response

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -32,6 +32,7 @@ class Serializer(object):
             # When a body isn't passed in, we'll read the response. We
             # also update the response with a new file handler to be
             # sure it acts as though it was never read.
+            # TODO switch to using FileWrapper or something like it
             body = response.read(decode_content=False)
             response._fp = io.BytesIO(body)
 


### PR DESCRIPTION
This is a sketch of a fix for #265.

This is an initial API review; basically it allows streaming data to and from file-like objects, which means memory usage can be fixed instead of `O(2N)` as it is now.

It should be completely backwards compatible: at the moment all but a single test pass. The new APIs are not tested yet, this is more of a sketch, although they are used somewhat.

If you're happy with this approach I can do further work to turn this into tested, documented code.