### PR TITLE
Add .venv and web_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ include
 docs/_build
 build/
 .tox
+.venv
+web_cache


### PR DESCRIPTION
Almost committed these on accident... any reason not to have them in `.gitgignore`?

![CleanShot 2021-11-29 at 11 45 08](https://user-images.githubusercontent.com/649496/143917359-f25aadbf-ae42-431a-83e4-086c9ee14757.png)
