### PR TITLE
Reduce memory use, part 2

### DIFF
--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -52,6 +52,14 @@ class SeparateBodyBaseCache(BaseCache):
 
         cache.set(key, serialized_metadata)
         cache.set_body(key)
+
+    Similarly, the body should be loaded separately via ``get_body()``.
     """
     def set_body(self, key, body):
+        raise NotImplementedError()
+
+    def get_body(self, key):
+        """
+        Return the body as file-like object.
+        """
         raise NotImplementedError()

--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -41,3 +41,17 @@ class DictCache(BaseCache):
         with self.lock:
             if key in self.data:
                 self.data.pop(key)
+
+
+class SeparateBodyBaseCache(BaseCache):
+    """
+    In this variant, the body is not stored mixed in with the metadata, but is
+    passed in (as a bytes-like object) in a separate call to ``set_body()``.
+
+    That is, the expected interaction pattern is::
+
+        cache.set(key, serialized_metadata)
+        cache.set_body(key)
+    """
+    def set_body(self, key, body):
+        raise NotImplementedError()

--- a/cachecontrol/caches/__init__.py
+++ b/cachecontrol/caches/__init__.py
@@ -2,5 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .file_cache import FileCache  # noqa
-from .redis_cache import RedisCache  # noqa
+from .file_cache import FileCache, SeparateBodyFileCache
+from .redis_cache import RedisCache
+
+
+__all__ = ["FileCache", "SeparateBodyFileCache", "RedisCache"]

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -27,15 +27,14 @@ PERMANENT_REDIRECT_STATUSES = (301, 308)
 def parse_uri(uri):
     """Parses a URI using the regex given in Appendix B of RFC 3986.
 
-        (scheme, authority, path, query, fragment) = parse_uri(uri)
+    (scheme, authority, path, query, fragment) = parse_uri(uri)
     """
     groups = URI.match(uri).groups()
     return (groups[1], groups[3], groups[4], groups[6], groups[8])
 
 
 class CacheController(object):
-    """An interface to see if request should cached or not.
-    """
+    """An interface to see if request should cached or not."""
 
     def __init__(
         self, cache=None, cache_etags=True, serializer=None, status_codes=None
@@ -251,6 +250,16 @@ class CacheController(object):
 
         return new_headers
 
+    def _cache_set(self, cache_url, request, response, body=None, expires_time=None):
+        """
+        Store the data in the cache.
+        """
+        self.cache.set(
+            cache_url,
+            self.serializer.dumps(request, response, body),
+            expires=expires_time,
+        )
+
     def cache_response(self, request, response, body=None, status_codes=None):
         """
         Algorithm for caching requests.
@@ -326,17 +335,13 @@ class CacheController(object):
 
             logger.debug("etag object cached for {0} seconds".format(expires_time))
             logger.debug("Caching due to etag")
-            self.cache.set(
-                cache_url,
-                self.serializer.dumps(request, response, body),
-                expires=expires_time,
-            )
+            self._cache_set(cache_url, request, response, body, expires_time)
 
         # Add to the cache any permanent redirects. We do this before looking
         # that the Date headers.
         elif int(response.status) in PERMANENT_REDIRECT_STATUSES:
             logger.debug("Caching permanent redirect")
-            self.cache.set(cache_url, self.serializer.dumps(request, response, b""))
+            self._cache_set(cache_url, request, response, b"")
 
         # Add to the cache if the response headers demand it. If there
         # is no date header then we can't do anything about expiring
@@ -347,10 +352,12 @@ class CacheController(object):
             if "max-age" in cc and cc["max-age"] > 0:
                 logger.debug("Caching b/c date exists and max-age > 0")
                 expires_time = cc["max-age"]
-                self.cache.set(
+                self._cache_set(
                     cache_url,
-                    self.serializer.dumps(request, response, body),
-                    expires=expires_time,
+                    request,
+                    response,
+                    body,
+                    expires_time,
                 )
 
             # If the request can expire, it means we should cache it
@@ -368,10 +375,12 @@ class CacheController(object):
                             expires_time
                         )
                     )
-                    self.cache.set(
+                    self._cache_set(
                         cache_url,
-                        self.serializer.dumps(request, response, body=body),
-                        expires=expires_time,
+                        request,
+                        response,
+                        body,
+                        expires_time,
                     )
 
     def update_cached_response(self, request, response):
@@ -410,6 +419,6 @@ class CacheController(object):
         cached_response.status = 200
 
         # update our cache
-        self.cache.set(cache_url, self.serializer.dumps(request, cached_response))
+        self._cache_set(cache_url, request, cached_response)
 
         return cached_response

--- a/cachecontrol/controller.py
+++ b/cachecontrol/controller.py
@@ -152,7 +152,7 @@ class CacheController(object):
             body_file = None
 
         # Check whether it can be deserialized
-        resp = self.serializer.loads(request, cache_data)
+        resp = self.serializer.loads(request, cache_data, body_file)
         if not resp:
             logger.warning("Cache entry deserialization failed, entry ignored")
             return False

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -99,7 +99,7 @@ class Serializer(object):
             # just treat it as a miss and return None
             return
 
-    def prepare_response(self, request, cached, body_file):
+    def prepare_response(self, request, cached, body_file=None):
         """Verify our vary headers match and construct a real urllib3
         HTTPResponse object.
         """
@@ -140,13 +140,13 @@ class Serializer(object):
 
         return HTTPResponse(body=body, preload_content=False, **cached["response"])
 
-    def _loads_v0(self, request, data, body_file):
+    def _loads_v0(self, request, data, body_file=None):
         # The original legacy cache data. This doesn't contain enough
         # information to construct everything we need, so we'll treat this as
         # a miss.
         return
 
-    def _loads_v1(self, request, data, body_file):
+    def _loads_v1(self, request, data, body_file=None):
         try:
             cached = pickle.loads(data)
         except ValueError:
@@ -154,7 +154,7 @@ class Serializer(object):
 
         return self.prepare_response(request, cached, body_file)
 
-    def _loads_v2(self, request, data, body_file):
+    def _loads_v2(self, request, data, body_file=None):
         assert body_file is None
         try:
             cached = json.loads(zlib.decompress(data).decode("utf8"))
@@ -181,7 +181,7 @@ class Serializer(object):
         # that they get rewritten out as v4 entries.
         return
 
-    def _loads_v4(self, request, data, body_file):
+    def _loads_v4(self, request, data, body_file=None):
         try:
             cached = msgpack.loads(data, raw=False)
         except ValueError:

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -44,7 +44,7 @@ class Serializer(object):
         #       enough to have msgpack know the difference.
         data = {
             u"response": {
-                u"body": body,
+                u"body": body,  # Empty bytestring if body is stored separately
                 u"headers": dict(
                     (text_type(k), text_type(v)) for k, v in response.headers.items()
                 ),
@@ -69,7 +69,7 @@ class Serializer(object):
 
         return b",".join([b"cc=4", msgpack.dumps(data, use_bin_type=True)])
 
-    def loads(self, request, data):
+    def loads(self, request, data, body_file=None):
         # Short circuit if we've been given an empty set of data
         if not data:
             return
@@ -92,14 +92,14 @@ class Serializer(object):
 
         # Dispatch to the actual load method for the given version
         try:
-            return getattr(self, "_loads_v{}".format(ver))(request, data)
+            return getattr(self, "_loads_v{}".format(ver))(request, data, body_file)
 
         except AttributeError:
             # This is a version we don't have a loads function for, so we'll
             # just treat it as a miss and return None
             return
 
-    def prepare_response(self, request, cached):
+    def prepare_response(self, request, cached, body_file):
         """Verify our vary headers match and construct a real urllib3
         HTTPResponse object.
         """
@@ -125,7 +125,10 @@ class Serializer(object):
         cached["response"]["headers"] = headers
 
         try:
-            body = io.BytesIO(body_raw)
+            if body_file is None:
+                body = io.BytesIO(body_raw)
+            else:
+                body = body_file
         except TypeError:
             # This can happen if cachecontrol serialized to v1 format (pickle)
             # using Python 2. A Python 2 str(byte string) will be unpickled as
@@ -137,21 +140,22 @@ class Serializer(object):
 
         return HTTPResponse(body=body, preload_content=False, **cached["response"])
 
-    def _loads_v0(self, request, data):
+    def _loads_v0(self, request, data, body_file):
         # The original legacy cache data. This doesn't contain enough
         # information to construct everything we need, so we'll treat this as
         # a miss.
         return
 
-    def _loads_v1(self, request, data):
+    def _loads_v1(self, request, data, body_file):
         try:
             cached = pickle.loads(data)
         except ValueError:
             return
 
-        return self.prepare_response(request, cached)
+        return self.prepare_response(request, cached, body_file)
 
-    def _loads_v2(self, request, data):
+    def _loads_v2(self, request, data, body_file):
+        assert body_file is None
         try:
             cached = json.loads(zlib.decompress(data).decode("utf8"))
         except (ValueError, zlib.error):
@@ -169,18 +173,18 @@ class Serializer(object):
             for k, v in cached["vary"].items()
         )
 
-        return self.prepare_response(request, cached)
+        return self.prepare_response(request, cached, body_file)
 
-    def _loads_v3(self, request, data):
+    def _loads_v3(self, request, data, body_file):
         # Due to Python 2 encoding issues, it's impossible to know for sure
         # exactly how to load v3 entries, thus we'll treat these as a miss so
         # that they get rewritten out as v4 entries.
         return
 
-    def _loads_v4(self, request, data):
+    def _loads_v4(self, request, data, body_file):
         try:
             cached = msgpack.loads(data, raw=False)
         except ValueError:
             return
 
-        return self.prepare_response(request, cached)
+        return self.prepare_response(request, cached, body_file)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,7 +10,7 @@
 0.12.11
 =======
 
-* ``FileCache`` now uses less memory.
+* Added new variant of ``FileCache``, ``SeparateBodyFileCache``, which uses less memory by storing the body in a separate file than metadata, and streaming data in and out directly to/from that file. Implemented by [Itamar Turner-Trauring](https://pythonspeed.com), work sponsored by [G-Research](https://www.gresearch.co.uk/technology-innovation-and-open-source/).
 
 0.12.7
 ======

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,7 +7,12 @@
  Release Notes
 ===============
 
-0.13.0
+0.12.11
+=======
+
+* ``FileCache`` now uses less memory.
+
+0.12.7
 ======
 
 * Dropped support for Python 2.7, 3.4, 3.5.

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -56,17 +56,33 @@ helpful in testing. Here is an example of how to use it: ::
   forever_cache = FileCache('.web_cache', forever=True)
   sess = CacheControl(requests.Session(), forever_cache)
 
+SeparateBodyFileCache
+=====================
 
-:A Note About Pickle:
+This is similar to ``FileCache``, but far more memory efficient, and therefore recommended if you expect to be caching large downloads.
+``FileCache`` results in memory usage that can be 2× or 3× of the downloaded file, whereas ``SeparateBodyFileCache`` should have fixed memory usage.
 
-  It should be noted that the `FileCache` uses pickle to store the
-  cached response. Prior to `requests 2.1`_, `requests.Response`
-  objects were not 'pickleable' due to the use of `IOBase` base
-  classes in `urllib3` `HTTPResponse` objects. In CacheControl we work
-  around this by patching the Response objects with the appropriate
-  `__getstate__` and `__setstate__` methods when the requests version
-  doesn't natively support Response pickling.
+The body of the request is stored in a separate file than metadata, and streamed in and out.
 
+It requires `lockfile`_ be installed as it prevents multiple threads from writing to the same file at the same time.
+
+.. note::
+
+  You can install this dependency automatically with pip
+  by requesting the *filecache* extra: ::
+
+    pip install cachecontrol[filecache]
+
+Here is an example of using the cache::
+
+  import requests
+  from cachecontrol import CacheControl
+  from cachecontrol.caches SeparateBodyFileCache
+
+  sess = CacheControl(requests.Session(),
+                      cache=SeparatedBodyFileCache('.web_cache'))
+
+``SeparateBodyFileCache`` supports the same options as ``FileCache``.
 
 
 RedisCache

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -21,7 +21,7 @@ class NullSerializer(object):
     def dumps(self, request, response):
         return response
 
-    def loads(self, request, data):
+    def loads(self, request, data, body_file=None):
         return data
 
 

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -18,7 +18,7 @@ class NullSerializer(object):
     def dumps(self, request, response, body=None):
         return response
 
-    def loads(self, request, data):
+    def loads(self, request, data, body_file=None):
         if data and getattr(data, "chunked", False):
             data.chunked = False
         return data

--- a/tests/test_max_age.py
+++ b/tests/test_max_age.py
@@ -15,7 +15,7 @@ class NullSerializer(object):
     def dumps(self, request, response, body=None):
         return response
 
-    def loads(self, request, data):
+    def loads(self, request, data, body_file=None):
         if data and getattr(data, "chunked", False):
             data.chunked = False
         return data

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -13,7 +13,7 @@ from random import randint, sample
 import pytest
 import requests
 from cachecontrol import CacheControl
-from cachecontrol.caches import FileCache
+from cachecontrol.caches import FileCache, SeparateBodyFileCache
 from lockfile import LockFile
 from lockfile.mkdirlockfile import MkdirLockFile
 
@@ -25,12 +25,14 @@ def randomdata():
     return "&{}={}".format(key, val)
 
 
-class TestStorageFileCache(object):
+class FileCacheTestsMixin(object):
+
+    FileCacheClass = None  # Either FileCache or SeparateBodyFileCache
 
     @pytest.fixture()
     def sess(self, url, tmpdir):
         self.url = url
-        self.cache = FileCache(str(tmpdir))
+        self.cache = self.FileCacheClass(str(tmpdir))
         sess = CacheControl(requests.Session(), cache=self.cache)
         yield sess
 
@@ -94,7 +96,7 @@ class TestStorageFileCache(object):
 
     def test_cant_use_dir_and_lock_class(self, tmpdir):
         with pytest.raises(ValueError):
-            FileCache(str(tmpdir), use_dir_lock=True, lock_class=object())
+            self.FileCacheClass(str(tmpdir), use_dir_lock=True, lock_class=object())
 
     @pytest.mark.parametrize(
         ("value", "expected"),
@@ -102,16 +104,16 @@ class TestStorageFileCache(object):
     )
     def test_simple_lockfile_arg(self, tmpdir, value, expected):
         if value is not None:
-            cache = FileCache(str(tmpdir), use_dir_lock=value)
+            cache = self.FileCacheClass(str(tmpdir), use_dir_lock=value)
         else:
-            cache = FileCache(str(tmpdir))
+            cache = self.FileCacheClass(str(tmpdir))
 
         assert issubclass(cache.lock_class, expected)
         cache.close()
 
     def test_lock_class(self, tmpdir):
         lock_class = object()
-        cache = FileCache(str(tmpdir), lock_class=lock_class)
+        cache = self.FileCacheClass(str(tmpdir), lock_class=lock_class)
         assert cache.lock_class is lock_class
         cache.close()
 
@@ -128,9 +130,39 @@ class TestStorageFileCache(object):
         assert True  # test verifies no exceptions were raised
 
 
+class TestFileCache(FileCacheTestsMixin):
+    """
+    Tests for ``FileCache``.
+    """
+    
+    FileCacheClass = FileCache
+
+    def test_body_stored_inline(self, sess):
+        """The body is stored together with the metadata."""
+        url = self.url + "cache_60"
+        response = sess.get(url)
+        body = response.content
+        response2 = sess.get(url)
+        assert response2.from_cache
+        assert response2.content == body
+
+        # OK now let's violate some abstraction boundaries to make sure body
+        # was stored in metadata file.
+        with open(self.cache._fn(url), "rb") as f:
+            assert body in f.read()
+        assert not os.path.exists(self.cache._fn(url) + ".body")
+
+
+class TestSeparateBodyFileCache(FileCacheTestsMixin):
+    """
+    Tests for ``SeparateBodyFileCache``
+    """
+
+    FileCacheClass = SeparateBodyFileCache
+
     def test_body_actually_stored_separately(self, sess):
         """
-        Body is stored and can be retrieved from the FileCache, with assurances
+        Body is stored and can be retrieved from the SeparateBodyFileCache, with assurances
         it's actually being loaded from separate file than metadata.
         """
         url = self.url + "cache_60"

--- a/tests/test_storage_filecache.py
+++ b/tests/test_storage_filecache.py
@@ -144,6 +144,8 @@ class TestStorageFileCache(object):
         # actually came from separate file.
         with open(self.cache._fn(url), "rb") as f:
             assert body not in f.read()
+        with open(self.cache._fn(url) + ".body", "rb") as f:
+            assert body == f.read()
         with open(self.cache._fn(url) + ".body", "wb") as f:
             f.write(b"CORRUPTED")
         response2 = sess.get(url)


### PR DESCRIPTION
Fixes #265 

Tested memory usage the following program:

```python
import requests
from tempfile import mkdtemp
from cachecontrol import CacheControl
from cachecontrol.caches.file_cache import FileCache

cache = FileCache(mkdtemp())
sess = CacheControl(requests.Session(), cache=cache)
for chunk in sess.get("https://files.pythonhosted.org/packages/76/9a/a245290ae642f78caf80d1454045d19119dd6f266a81f02a1aa7aa89ba99/numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", stream=True).iter_content(16384):
    pass
```

Peak memory in master was 85MB (as tracked by Fil). In this PR, it was 7.7MB; I expect this to not change with file size. Given the downloaded file is 27MB, we've gone from `O(3N)` to `O(1)` memory usage.
