### PR TITLE
Replace "cachecontrol" imports with relative imports

### DIFF
--- a/cachecontrol/_cmd.py
+++ b/cachecontrol/_cmd.py
@@ -6,9 +6,9 @@ import logging
 
 import requests
 
-from cachecontrol.adapter import CacheControlAdapter
-from cachecontrol.cache import DictCache
-from cachecontrol.controller import logger
+from .adapter import CacheControlAdapter
+from .cache import DictCache
+from .controller import logger
 
 from argparse import ArgumentParser
 

--- a/cachecontrol/caches/redis_cache.py
+++ b/cachecontrol/caches/redis_cache.py
@@ -5,7 +5,8 @@
 from __future__ import division
 
 from datetime import datetime
-from cachecontrol.cache import BaseCache
+
+from ..cache import BaseCache
 
 
 class RedisCache(BaseCache):


### PR DESCRIPTION
Vendoring this dependency and noticed that relative imports are used in most places, but not everywhere. Since they are already used elsewhere, it seems like changing the few remaining ones would be ok.

Thanks!