### PR TITLE
Packaging the tests, or not

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft tests/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup_params = dict(
     author_email="eric@ionrock.org",
     url="https://github.com/ionrock/cachecontrol",
     keywords="requests http caching web",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     package_data={"": ["LICENSE.txt"]},
     package_dir={"cachecontrol": "cachecontrol"},
     include_package_data=True,


### PR DESCRIPTION
Fixes #281, #282

- first commit explicitly excludes tests from the binary distribution, it is indeed unconventional to include them
- second commit explicitly re-adds them to the source distribution
  - I don't think there's universal consensus about whether this is desirable or not eg [here](https://discuss.python.org/t/should-sdists-include-docs-and-tests/14578) is a recent discussion
  - but it seems harmless and seeing as how #281 explicitly asks for them, well why not?

