### PR TITLE
Use Python's unittest mock

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,7 +7,6 @@
 tox
 pytest-cov
 pytest
-mock
 cherrypy
 sphinx
 redis

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import mock
+from unittest import mock
 import pytest
 
 from requests import Session

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -6,7 +6,7 @@
 Unit tests that verify our caching methods work correctly.
 """
 import pytest
-from mock import ANY, Mock
+from unittest.mock import ANY, Mock
 import time
 from tempfile import mkdtemp
 

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 import requests
 

--- a/tests/test_expires_heuristics.py
+++ b/tests/test_expires_heuristics.py
@@ -8,7 +8,7 @@ import time
 from email.utils import formatdate, parsedate
 from datetime import datetime
 
-from mock import Mock
+from unittest.mock import Mock
 from requests import Session, get
 
 from cachecontrol import CacheControl

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,7 @@
 import msgpack
 import requests
 
-from mock import Mock
+from unittest.mock import Mock
 
 from cachecontrol.compat import pickle
 from cachecontrol.serialize import Serializer

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 
-from mock import Mock
+from unittest.mock import Mock
 from cachecontrol.caches import RedisCache
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ python =
 
 [testenv]
 deps = pytest
-       mock
        cherrypy
        redis
        filelock


### PR DESCRIPTION
Since 3.3 Python unittest module supports mock and the seperate mock module is deprecated.