### PR TITLE
fix: double reading error on urllib3 2.0

### DIFF
--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -34,6 +34,7 @@ class Serializer(object):
             # sure it acts as though it was never read.
             body = response.read(decode_content=False)
             response._fp = io.BytesIO(body)
+            response.length_remaining = len(body)
 
         # NOTE: This is all a bit weird, but it's really important that on
         #       Python 2.x these objects are unicode and not str, even when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,16 @@ class SimpleApp(object):
         for i in range(10):
             yield pformat(i).encode("utf8")
 
+    def fixed_length(self, env, start_response):
+        body = b"0123456789"
+        headers = [
+            ("Content-Type", "text/plain"),
+            ("Cache-Control", "max-age=5000"),
+            ("Content-Length", str(len(body)))
+        ]
+        start_response("200 OK", headers)
+        return [body]
+
     def __call__(self, env, start_response):
         func = self.dispatch(env)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -135,3 +135,9 @@ class TestSerializer(object):
         # handle. Reading it again proves we're resetting the internal
         # file handle with a buffer.
         assert original_resp.raw.read()
+
+    def test_no_incomplete_read_on_dumps(self, url):
+        resp = requests.get(url + "fixed_length", stream=True)
+        self.serializer.dumps(resp.request, resp.raw)
+        
+        assert resp.content == b"0123456789"


### PR DESCRIPTION
This patch resets the length_remaining attribute when replacing the resp._fp

Fixes #295

Signed-off-by: Frost Ming <me@frostming.com>