### PR TITLE
Fix #292: disuse HTTPResponse.strict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        os: ["macos-10.15", "windows-latest", "ubuntu-latest"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ["macos-latest", "windows-latest", "ubuntu-latest"]
+        include:
+          - python-version: "3.6"
+            os: "ubuntu-20.04"
+          - python-version: "3.6"
+            os: "windows-latest"
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: ["macos-10.15", "windows-latest", "ubuntu-latest"]

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -51,7 +51,6 @@ class Serializer(object):
                 u"status": response.status,
                 u"version": response.version,
                 u"reason": text_type(response.reason),
-                u"strict": response.strict,
                 u"decode_content": response.decode_content,
             }
         }

--- a/cachecontrol/serialize.py
+++ b/cachecontrol/serialize.py
@@ -137,6 +137,9 @@ class Serializer(object):
             #     TypeError: 'str' does not support the buffer interface
             body = io.BytesIO(body_raw.encode("utf8"))
 
+        # Discard any `strict` parameter serialized by older version of cachecontrol.
+        cached["response"].pop("strict", None)
+
         return HTTPResponse(body=body, preload_content=False, **cached["response"])
 
     def _loads_v0(self, request, data, body_file=None):

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2015 Eric Larson
 #
 # SPDX-License-Identifier: Apache-2.0
+from contextlib import ExitStack
+from contextlib import suppress
 
 import pytest
 
@@ -134,11 +136,20 @@ class TestReleaseConnection(object):
 
         resp = Mock(status=304, headers={})
 
-        # This is how the urllib3 response is created in
-        # requests.adapters
-        response_mod = "requests.adapters.HTTPResponse.from_httplib"
+        # These are various ways the the urllib3 response can created
+        # in requests.adapters.  Which one is actually used depends
+        # on which version if `requests` is in use, as well as perhaps
+        # other parameters.
+        response_mods = [
+            "requests.adapters.HTTPResponse.from_httplib",
+            "urllib3.HTTPConnectionPool.urlopen",
+        ]
 
-        with patch(response_mod, Mock(return_value=resp)):
+        with ExitStack() as stack:
+            for mod in response_mods:
+                with suppress(ImportError):
+                    stack.enter_context(patch(mod, Mock(return_value=resp)))
+
             sess.get(etag_url)
             assert resp.read.called
             assert resp.release_conn.called

--- a/tests/test_vary.py
+++ b/tests/test_vary.py
@@ -33,7 +33,6 @@ class TestVary(object):
             cached.status == resp.raw.status,
             cached.version == resp.raw.version,
             cached.reason == resp.raw.reason,
-            cached.strict == resp.raw.strict,
             cached.decode_content == resp.raw.decode_content,
         ]
 


### PR DESCRIPTION
This is an alternative PR to #294. It is more-or-less functionally equivalent to that PR. This alternative is being provided in case it turns out that the only reason #294 isn't being merged is that it includes formatting changes, etc. There are a [couple](https://github.com/ionrock/cachecontrol/pull/294#issuecomment-1537762240) of [comments](https://github.com/ionrock/cachecontrol/issues/300#issuecomment-1560211551) that indicate that might be the case. It seems that #292 affects a sufficiently wide collection of users that a timely fix is important.

Fixes #292
Fixes #293 

## What is here

- Omit the `strict` attribute from the HTTPRequest (de)serialization.
- A minimal set of test changes/fixes so that the tests run (and pass):
   - Fix bitrot in the CI workflow so that the tests actually run.
   - Fix bitrot in `test_etag.py` for `requests>=2.29`.

## Notes

As noted in [this comment](https://github.com/ionrock/cachecontrol/pull/294#issuecomment-1559991393) on #294, the `strict` parameter only has an effect if running under Python 2. Since cachecontrol no longer supports Python 2 there is no reason not to remove support for `strict` altogether (as is done here).
